### PR TITLE
Organize modules and design system

### DIFF
--- a/Industrious/ContentView.swift
+++ b/Industrious/ContentView.swift
@@ -1,86 +1,43 @@
-//
-//  ContentView.swift
-//  Industrious
-//
-//  Created by Johnny Villegas on 9/3/25.
-//
-
 import SwiftUI
-import CoreData
 
 struct ContentView: View {
-    @Environment(\.managedObjectContext) private var viewContext
-
-    @FetchRequest(
-        sortDescriptors: [NSSortDescriptor(keyPath: \Item.timestamp, ascending: true)],
-        animation: .default)
-    private var items: FetchedResults<Item>
-
     var body: some View {
-        NavigationView {
-            List {
-                ForEach(items) { item in
-                    NavigationLink {
-                        Text("Item at \(item.timestamp!, formatter: itemFormatter)")
-                    } label: {
-                        Text(item.timestamp!, formatter: itemFormatter)
-                    }
+        TabView {
+            DashboardView()
+                .tabItem {
+                    SFSymbol.dashboard.image
+                    Text("Dashboard")
                 }
-                .onDelete(perform: deleteItems)
-            }
-            .toolbar {
-                ToolbarItem(placement: .navigationBarTrailing) {
-                    EditButton()
+            SessionsView()
+                .tabItem {
+                    SFSymbol.sessions.image
+                    Text("Sessions")
                 }
-                ToolbarItem {
-                    Button(action: addItem) {
-                        Label("Add Item", systemImage: "plus")
-                    }
+            PlannerView()
+                .tabItem {
+                    SFSymbol.planner.image
+                    Text("Planner")
                 }
-            }
-            Text("Select an item")
+            StudiesView()
+                .tabItem {
+                    SFSymbol.studies.image
+                    Text("Studies")
+                }
+            HistoryView()
+                .tabItem {
+                    SFSymbol.history.image
+                    Text("History")
+                }
+            SettingsView()
+                .tabItem {
+                    SFSymbol.settings.image
+                    Text("Settings")
+                }
         }
-    }
-
-    private func addItem() {
-        withAnimation {
-            let newItem = Item(context: viewContext)
-            newItem.timestamp = Date()
-
-            do {
-                try viewContext.save()
-            } catch {
-                // Replace this implementation with code to handle the error appropriately.
-                // fatalError() causes the application to generate a crash log and terminate. You should not use this function in a shipping application, although it may be useful during development.
-                let nsError = error as NSError
-                fatalError("Unresolved error \(nsError), \(nsError.userInfo)")
-            }
-        }
-    }
-
-    private func deleteItems(offsets: IndexSet) {
-        withAnimation {
-            offsets.map { items[$0] }.forEach(viewContext.delete)
-
-            do {
-                try viewContext.save()
-            } catch {
-                // Replace this implementation with code to handle the error appropriately.
-                // fatalError() causes the application to generate a crash log and terminate. You should not use this function in a shipping application, although it may be useful during development.
-                let nsError = error as NSError
-                fatalError("Unresolved error \(nsError), \(nsError.userInfo)")
-            }
-        }
+        .tint(AppColor.primary)
     }
 }
 
-private let itemFormatter: DateFormatter = {
-    let formatter = DateFormatter()
-    formatter.dateStyle = .short
-    formatter.timeStyle = .medium
-    return formatter
-}()
-
 #Preview {
-    ContentView().environment(\.managedObjectContext, PersistenceController.preview.container.viewContext)
+    ContentView()
 }

--- a/Industrious/Modules/Dashboard/DashboardView.swift
+++ b/Industrious/Modules/Dashboard/DashboardView.swift
@@ -1,0 +1,16 @@
+import SwiftUI
+
+struct DashboardView: View {
+    var body: some View {
+        Text("Dashboard")
+            .font(Typography.heading())
+            .foregroundStyle(AppColor.textPrimary)
+            .padding(Spacing.m)
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .background(AppColor.background)
+    }
+}
+
+#Preview {
+    DashboardView()
+}

--- a/Industrious/Modules/History/HistoryView.swift
+++ b/Industrious/Modules/History/HistoryView.swift
@@ -1,0 +1,16 @@
+import SwiftUI
+
+struct HistoryView: View {
+    var body: some View {
+        Text("History")
+            .font(Typography.heading())
+            .foregroundStyle(AppColor.textPrimary)
+            .padding(Spacing.m)
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .background(AppColor.background)
+    }
+}
+
+#Preview {
+    HistoryView()
+}

--- a/Industrious/Modules/Planner/PlannerView.swift
+++ b/Industrious/Modules/Planner/PlannerView.swift
@@ -1,0 +1,16 @@
+import SwiftUI
+
+struct PlannerView: View {
+    var body: some View {
+        Text("Planner")
+            .font(Typography.heading())
+            .foregroundStyle(AppColor.textPrimary)
+            .padding(Spacing.m)
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .background(AppColor.background)
+    }
+}
+
+#Preview {
+    PlannerView()
+}

--- a/Industrious/Modules/Sessions/SessionsView.swift
+++ b/Industrious/Modules/Sessions/SessionsView.swift
@@ -1,0 +1,16 @@
+import SwiftUI
+
+struct SessionsView: View {
+    var body: some View {
+        Text("Sessions")
+            .font(Typography.heading())
+            .foregroundStyle(AppColor.textPrimary)
+            .padding(Spacing.m)
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .background(AppColor.background)
+    }
+}
+
+#Preview {
+    SessionsView()
+}

--- a/Industrious/Modules/Settings/SettingsView.swift
+++ b/Industrious/Modules/Settings/SettingsView.swift
@@ -1,0 +1,16 @@
+import SwiftUI
+
+struct SettingsView: View {
+    var body: some View {
+        Text("Settings")
+            .font(Typography.heading())
+            .foregroundStyle(AppColor.textPrimary)
+            .padding(Spacing.m)
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .background(AppColor.background)
+    }
+}
+
+#Preview {
+    SettingsView()
+}

--- a/Industrious/Modules/Studies/StudiesView.swift
+++ b/Industrious/Modules/Studies/StudiesView.swift
@@ -1,0 +1,16 @@
+import SwiftUI
+
+struct StudiesView: View {
+    var body: some View {
+        Text("Studies")
+            .font(Typography.heading())
+            .foregroundStyle(AppColor.textPrimary)
+            .padding(Spacing.m)
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .background(AppColor.background)
+    }
+}
+
+#Preview {
+    StudiesView()
+}

--- a/Industrious/Persistence.swift
+++ b/Industrious/Persistence.swift
@@ -29,18 +29,17 @@ struct PersistenceController {
         return result
     }()
 
-    let container: NSPersistentContainer
+    let container: NSPersistentCloudKitContainer
 
     init(inMemory: Bool = false) {
-        container = NSPersistentContainer(name: "Industrious")
+        container = NSPersistentCloudKitContainer(name: "Industrious")
         if inMemory {
-            container.persistentStoreDescriptions.first!.url = URL(fileURLWithPath: "/dev/null")
+            container.persistentStoreDescriptions.first?.url = URL(fileURLWithPath: "/dev/null")
         }
-        container.loadPersistentStores(completionHandler: { (storeDescription, error) in
+        container.loadPersistentStores(completionHandler: { (_, error) in
             if let error = error as NSError? {
                 // Replace this implementation with code to handle the error appropriately.
                 // fatalError() causes the application to generate a crash log and terminate. You should not use this function in a shipping application, although it may be useful during development.
-
                 /*
                  Typical reasons for an error here include:
                  * The parent directory does not exist, cannot be created, or disallows writing.

--- a/Industrious/Shared/DesignSystem/AppColor.swift
+++ b/Industrious/Shared/DesignSystem/AppColor.swift
@@ -1,0 +1,9 @@
+import SwiftUI
+
+enum AppColor {
+    static let primary = Color(red: 0.22, green: 0.47, blue: 0.82)
+    static let secondary = Color(red: 0.95, green: 0.77, blue: 0.06)
+    static let background = Color(red: 0.95, green: 0.95, blue: 0.97)
+    static let textPrimary = Color.primary
+    static let textSecondary = Color.secondary
+}

--- a/Industrious/Shared/DesignSystem/Spacing.swift
+++ b/Industrious/Shared/DesignSystem/Spacing.swift
@@ -1,0 +1,9 @@
+import SwiftUI
+
+enum Spacing {
+    static let xs: CGFloat = 4
+    static let s: CGFloat = 8
+    static let m: CGFloat = 16
+    static let l: CGFloat = 24
+    static let xl: CGFloat = 32
+}

--- a/Industrious/Shared/DesignSystem/Symbols.swift
+++ b/Industrious/Shared/DesignSystem/Symbols.swift
@@ -1,0 +1,14 @@
+import SwiftUI
+
+enum SFSymbol: String {
+    case dashboard = "rectangle.grid.2x2"
+    case sessions = "clock"
+    case planner = "calendar"
+    case studies = "book"
+    case history = "clock.arrow.circlepath"
+    case settings = "gear"
+
+    var image: Image {
+        Image(systemName: rawValue)
+    }
+}

--- a/Industrious/Shared/DesignSystem/Typography.swift
+++ b/Industrious/Shared/DesignSystem/Typography.swift
@@ -1,0 +1,15 @@
+import SwiftUI
+
+enum Typography {
+    static func heading(_ size: CGFloat = 24) -> Font {
+        .system(size: size, weight: .bold, design: .rounded)
+    }
+
+    static func body(_ size: CGFloat = 16) -> Font {
+        .system(size: size, weight: .regular, design: .rounded)
+    }
+
+    static func caption(_ size: CGFloat = 12) -> Font {
+        .system(size: size, weight: .medium, design: .rounded)
+    }
+}


### PR DESCRIPTION
## Summary
- enable CloudKit-backed persistence container
- scaffold Sessions, Dashboard, Planner, Studies, History, and Settings modules
- add shared design system for colors, typography, spacing, and SF Symbols

## Testing
- `xcodebuild test -project Industrious.xcodeproj -scheme Industrious -destination 'platform=iOS Simulator,name=iPhone 14'` *(command not found: xcodebuild)*


------
https://chatgpt.com/codex/tasks/task_e_68b8fb1689dc832ea5832c30d74d9811