### PR TITLE
Add core data entities, enums, and analytics

### DIFF
--- a/Industrious/Industrious.xcdatamodeld/Industrious.xcdatamodel/contents
+++ b/Industrious/Industrious.xcdatamodeld/Industrious.xcdatamodel/contents
@@ -3,7 +3,44 @@
     <entity name="Item" representedClassName="Item" syncable="YES" codeGenerationType="class">
         <attribute name="timestamp" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
     </entity>
+    <entity name="Session" representedClassName="Session" syncable="YES" codeGenerationType="class">
+        <attribute name="id" optional="NO" attributeType="UUID" usesScalarValueType="NO"/>
+        <attribute name="start" optional="NO" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="end" optional="NO" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="activityTypeRaw" optional="NO" attributeType="String" usesScalarValueType="NO"/>
+        <relationship name="study" optional="YES" toMany="NO" deletionRule="Nullify" destinationEntity="Study" inverseName="sessions" inverseEntity="Study"/>
+    </entity>
+    <entity name="CounterEntry" representedClassName="CounterEntry" syncable="YES" codeGenerationType="class">
+        <attribute name="id" optional="NO" attributeType="UUID" usesScalarValueType="NO"/>
+        <attribute name="date" optional="NO" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="kindRaw" optional="NO" attributeType="String" usesScalarValueType="NO"/>
+        <attribute name="value" optional="NO" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+    </entity>
+    <entity name="Study" representedClassName="Study" syncable="YES" codeGenerationType="class">
+        <attribute name="id" optional="NO" attributeType="UUID" usesScalarValueType="NO"/>
+        <attribute name="title" optional="NO" attributeType="String" usesScalarValueType="NO"/>
+        <relationship name="sessions" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Session" inverseName="study" inverseEntity="Session"/>
+    </entity>
+    <entity name="DayOff" representedClassName="DayOff" syncable="YES" codeGenerationType="class">
+        <attribute name="id" optional="NO" attributeType="UUID" usesScalarValueType="NO"/>
+        <attribute name="date" optional="NO" attributeType="Date" usesScalarValueType="NO"/>
+    </entity>
+    <entity name="Goal" representedClassName="Goal" syncable="YES" codeGenerationType="class">
+        <attribute name="id" optional="NO" attributeType="UUID" usesScalarValueType="NO"/>
+        <attribute name="title" optional="NO" attributeType="String" usesScalarValueType="NO"/>
+        <attribute name="target" optional="NO" attributeType="Double" defaultValueString="0" usesScalarValueType="YES"/>
+    </entity>
+    <entity name="Preference" representedClassName="Preference" syncable="YES" codeGenerationType="class">
+        <attribute name="key" optional="NO" attributeType="String" usesScalarValueType="NO"/>
+        <attribute name="value" optional="YES" attributeType="String" usesScalarValueType="NO"/>
+    </entity>
     <elements>
         <element name="Item" positionX="-63" positionY="-18" width="128" height="44"/>
+        <element name="Session" positionX="100" positionY="0" width="128" height="128"/>
+        <element name="CounterEntry" positionX="250" positionY="0" width="128" height="128"/>
+        <element name="Study" positionX="100" positionY="200" width="128" height="128"/>
+        <element name="DayOff" positionX="250" positionY="200" width="128" height="128"/>
+        <element name="Goal" positionX="100" positionY="400" width="128" height="128"/>
+        <element name="Preference" positionX="250" positionY="400" width="128" height="128"/>
     </elements>
 </model>

--- a/Industrious/Models/Aggregation.swift
+++ b/Industrious/Models/Aggregation.swift
@@ -1,0 +1,45 @@
+import Foundation
+import CoreData
+
+struct MonthKey: Hashable {
+    let year: Int
+    let month: Int
+}
+
+struct Aggregator {
+    static func sessionDurationsByMonth(context: NSManagedObjectContext, activity: ActivityType? = nil) throws -> [MonthKey: TimeInterval] {
+        let request: NSFetchRequest<Session> = Session.fetchRequest()
+        if let activity = activity {
+            request.predicate = NSPredicate(format: "activityTypeRaw == %@", activity.rawValue)
+        }
+        let sessions = try context.fetch(request)
+        var result: [MonthKey: TimeInterval] = [:]
+        let calendar = Calendar.current
+        for session in sessions {
+            let components = calendar.dateComponents([.year, .month], from: session.start)
+            guard let year = components.year, let month = components.month else { continue }
+            let key = MonthKey(year: year, month: month)
+            let duration = session.end.timeIntervalSince(session.start)
+            result[key, default: 0] += duration
+        }
+        return result
+    }
+
+    static func counterTotalsByMonth(context: NSManagedObjectContext, kind: CounterKind? = nil) throws -> [MonthKey: Int64] {
+        let request: NSFetchRequest<CounterEntry> = CounterEntry.fetchRequest()
+        if let kind = kind {
+            request.predicate = NSPredicate(format: "kindRaw == %@", kind.rawValue)
+        }
+        let entries = try context.fetch(request)
+        var result: [MonthKey: Int64] = [:]
+        let calendar = Calendar.current
+        for entry in entries {
+            let components = calendar.dateComponents([.year, .month], from: entry.date)
+            guard let year = components.year, let month = components.month else { continue }
+            let key = MonthKey(year: year, month: month)
+            result[key, default: 0] += entry.value
+        }
+        return result
+    }
+}
+

--- a/Industrious/Models/Entities.swift
+++ b/Industrious/Models/Entities.swift
@@ -1,0 +1,96 @@
+import Foundation
+import CoreData
+
+@objc(Session)
+public class Session: NSManagedObject {
+    @NSManaged public var id: UUID
+    @NSManaged public var start: Date
+    @NSManaged public var end: Date
+    @NSManaged public var activityTypeRaw: String
+    @NSManaged public var study: Study?
+
+    public var activityType: ActivityType {
+        get { ActivityType(rawValue: activityTypeRaw) ?? .study }
+        set { activityTypeRaw = newValue.rawValue }
+    }
+}
+
+extension Session {
+    @nonobjc public class func fetchRequest() -> NSFetchRequest<Session> {
+        NSFetchRequest<Session>(entityName: "Session")
+    }
+}
+
+@objc(CounterEntry)
+public class CounterEntry: NSManagedObject {
+    @NSManaged public var id: UUID
+    @NSManaged public var date: Date
+    @NSManaged public var kindRaw: String
+    @NSManaged public var value: Int64
+
+    public var kind: CounterKind {
+        get { CounterKind(rawValue: kindRaw) ?? .session }
+        set { kindRaw = newValue.rawValue }
+    }
+}
+
+extension CounterEntry {
+    @nonobjc public class func fetchRequest() -> NSFetchRequest<CounterEntry> {
+        NSFetchRequest<CounterEntry>(entityName: "CounterEntry")
+    }
+}
+
+@objc(Study)
+public class Study: NSManagedObject {
+    @NSManaged public var id: UUID
+    @NSManaged public var title: String
+    @NSManaged public var sessions: Set<Session>?
+
+    public var sessionsArray: [Session] {
+        sessions?.sorted { $0.start < $1.start } ?? []
+    }
+}
+
+extension Study {
+    @nonobjc public class func fetchRequest() -> NSFetchRequest<Study> {
+        NSFetchRequest<Study>(entityName: "Study")
+    }
+}
+
+@objc(DayOff)
+public class DayOff: NSManagedObject {
+    @NSManaged public var id: UUID
+    @NSManaged public var date: Date
+}
+
+extension DayOff {
+    @nonobjc public class func fetchRequest() -> NSFetchRequest<DayOff> {
+        NSFetchRequest<DayOff>(entityName: "DayOff")
+    }
+}
+
+@objc(Goal)
+public class Goal: NSManagedObject {
+    @NSManaged public var id: UUID
+    @NSManaged public var title: String
+    @NSManaged public var target: Double
+}
+
+extension Goal {
+    @nonobjc public class func fetchRequest() -> NSFetchRequest<Goal> {
+        NSFetchRequest<Goal>(entityName: "Goal")
+    }
+}
+
+@objc(Preference)
+public class Preference: NSManagedObject {
+    @NSManaged public var key: String
+    @NSManaged public var value: String?
+}
+
+extension Preference {
+    @nonobjc public class func fetchRequest() -> NSFetchRequest<Preference> {
+        NSFetchRequest<Preference>(entityName: "Preference")
+    }
+}
+

--- a/Industrious/Models/Enums.swift
+++ b/Industrious/Models/Enums.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+enum ActivityType: String, CaseIterable, Codable {
+    case study
+    case breakTime
+    case meeting
+    case other
+}
+
+enum CounterKind: String, CaseIterable, Codable {
+    case session
+    case dayOff
+    case goal
+}
+

--- a/Industrious/Models/MigrationHelpers.swift
+++ b/Industrious/Models/MigrationHelpers.swift
@@ -1,0 +1,26 @@
+import Foundation
+import CoreData
+
+struct MigrationHelper {
+    static func migrateLegacyItems(context: NSManagedObjectContext) throws {
+        let request = NSFetchRequest<NSManagedObject>(entityName: "Item")
+        let items = try context.fetch(request)
+        guard !items.isEmpty else { return }
+        for item in items {
+            let session = Session(context: context)
+            session.id = UUID()
+            if let timestamp = item.value(forKey: "timestamp") as? Date {
+                session.start = timestamp
+                session.end = timestamp
+            } else {
+                let now = Date()
+                session.start = now
+                session.end = now
+            }
+            session.activityType = .study
+            context.delete(item)
+        }
+        try context.save()
+    }
+}
+

--- a/Industrious/Persistence.swift
+++ b/Industrious/Persistence.swift
@@ -15,8 +15,11 @@ struct PersistenceController {
         let result = PersistenceController(inMemory: true)
         let viewContext = result.container.viewContext
         for _ in 0..<10 {
-            let newItem = Item(context: viewContext)
-            newItem.timestamp = Date()
+            let session = Session(context: viewContext)
+            session.id = UUID()
+            session.start = Date()
+            session.end = Date()
+            session.activityType = .study
         }
         do {
             try viewContext.save()
@@ -52,5 +55,6 @@ struct PersistenceController {
             }
         })
         container.viewContext.automaticallyMergesChangesFromParent = true
+        try? MigrationHelper.migrateLegacyItems(context: container.viewContext)
     }
 }


### PR DESCRIPTION
## Summary
- expand data model with sessions, counters, studies, days off, goals, and preferences
- introduce ActivityType and CounterKind enums with managed object subclasses
- add migration helper and monthly aggregation utilities

## Testing
- `swiftc Industrious/Models/Enums.swift Industrious/Models/Entities.swift Industrious/Models/MigrationHelpers.swift Industrious/Models/Aggregation.swift Industrious/Persistence.swift -o /tmp/app` *(fails: no such module 'CoreData')*

------
https://chatgpt.com/codex/tasks/task_e_68b901e6b0dc832eb53042f94b2c847f