### PR TITLE
Add session timer and start session view

### DIFF
--- a/Industrious/Industrious.xcdatamodeld/Industrious.xcdatamodel/contents
+++ b/Industrious/Industrious.xcdatamodeld/Industrious.xcdatamodel/contents
@@ -8,6 +8,9 @@
         <attribute name="start" optional="NO" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="end" optional="NO" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="activityTypeRaw" optional="NO" attributeType="String" usesScalarValueType="NO"/>
+        <attribute name="isCreditHour" optional="NO" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="companionRaw" optional="NO" attributeType="String" usesScalarValueType="NO"/>
+        <attribute name="notes" optional="YES" attributeType="String" usesScalarValueType="NO"/>
         <relationship name="study" optional="YES" toMany="NO" deletionRule="Nullify" destinationEntity="Study" inverseName="sessions" inverseEntity="Study"/>
     </entity>
     <entity name="CounterEntry" representedClassName="CounterEntry" syncable="YES" codeGenerationType="class">

--- a/Industrious/Models/Entities.swift
+++ b/Industrious/Models/Entities.swift
@@ -7,11 +7,19 @@ public class Session: NSManagedObject {
     @NSManaged public var start: Date
     @NSManaged public var end: Date
     @NSManaged public var activityTypeRaw: String
+    @NSManaged public var isCreditHour: Bool
+    @NSManaged public var companionRaw: String
+    @NSManaged public var notes: String?
     @NSManaged public var study: Study?
 
     public var activityType: ActivityType {
         get { ActivityType(rawValue: activityTypeRaw) ?? .study }
         set { activityTypeRaw = newValue.rawValue }
+    }
+
+    public var companion: CompanionType {
+        get { CompanionType(rawValue: companionRaw) ?? .solo }
+        set { companionRaw = newValue.rawValue }
     }
 }
 

--- a/Industrious/Models/Enums.swift
+++ b/Industrious/Models/Enums.swift
@@ -13,3 +13,9 @@ enum CounterKind: String, CaseIterable, Codable {
     case goal
 }
 
+enum CompanionType: String, CaseIterable, Codable {
+    case solo
+    case friend
+    case group
+}
+

--- a/Industrious/Models/MigrationHelpers.swift
+++ b/Industrious/Models/MigrationHelpers.swift
@@ -18,6 +18,9 @@ struct MigrationHelper {
                 session.end = now
             }
             session.activityType = .study
+            session.isCreditHour = false
+            session.companion = .solo
+            session.notes = nil
             context.delete(item)
         }
         try context.save()

--- a/Industrious/Modules/Sessions/SessionViewModel.swift
+++ b/Industrious/Modules/Sessions/SessionViewModel.swift
@@ -1,0 +1,66 @@
+import Foundation
+import CoreData
+
+@MainActor
+class SessionViewModel: ObservableObject {
+    @Published var selectedActivity: ActivityType = .study
+    @Published var isCreditHour: Bool = false
+    @Published var selectedCompanion: CompanionType = .solo
+    @Published var notes: String = ""
+    @Published var elapsed: TimeInterval = 0
+    @Published var isRunning: Bool = false
+    @Published var counter: Int = 0
+
+    private var timer: Timer?
+    private var startDate: Date?
+
+    func start() {
+        startDate = Date()
+        elapsed = 0
+        isRunning = true
+        timer = Timer.scheduledTimer(withTimeInterval: 1, repeats: true) { [weak self] _ in
+            guard let self = self, let startDate = self.startDate else { return }
+            self.elapsed = Date().timeIntervalSince(startDate)
+        }
+    }
+
+    func stop(context: NSManagedObjectContext) {
+        guard let startDate = startDate else { return }
+        timer?.invalidate()
+        isRunning = false
+        let endDate = Date()
+
+        let session = Session(context: context)
+        session.id = UUID()
+        session.start = startDate
+        session.end = endDate
+        session.activityType = selectedActivity
+        session.isCreditHour = isCreditHour
+        session.companion = selectedCompanion
+        session.notes = notes.isEmpty ? nil : notes
+
+        do {
+            try context.save()
+        } catch {
+            print("Failed to save session: \(error)")
+        }
+
+        reset()
+    }
+
+    func reset() {
+        timer?.invalidate()
+        timer = nil
+        elapsed = 0
+        startDate = nil
+        isRunning = false
+    }
+
+    var timeString: String {
+        let formatter = DateComponentsFormatter()
+        formatter.unitsStyle = .positional
+        formatter.allowedUnits = [.hour, .minute, .second]
+        formatter.zeroFormattingBehavior = .pad
+        return formatter.string(from: elapsed) ?? "00:00:00"
+    }
+}

--- a/Industrious/Modules/Sessions/SessionsView.swift
+++ b/Industrious/Modules/Sessions/SessionsView.swift
@@ -1,13 +1,21 @@
 import SwiftUI
 
 struct SessionsView: View {
+    @State private var showingStart = false
+
     var body: some View {
-        Text("Sessions")
-            .font(Typography.heading())
-            .foregroundStyle(AppColor.textPrimary)
-            .padding(Spacing.m)
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
-            .background(AppColor.background)
+        VStack {
+            Button("Start Session") { showingStart = true }
+                .font(Typography.heading())
+                .foregroundStyle(AppColor.textPrimary)
+                .padding(Spacing.m)
+            Spacer()
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(AppColor.background)
+        .sheet(isPresented: $showingStart) {
+            StartSessionView()
+        }
     }
 }
 

--- a/Industrious/Modules/Sessions/StartSessionView.swift
+++ b/Industrious/Modules/Sessions/StartSessionView.swift
@@ -1,0 +1,95 @@
+import SwiftUI
+
+struct StartSessionView: View {
+    @StateObject private var viewModel = SessionViewModel()
+    @Environment(\.managedObjectContext) private var context
+
+    var body: some View {
+        VStack(spacing: Spacing.l) {
+            HStack(spacing: Spacing.l) {
+                Button(action: { if viewModel.counter > 0 { viewModel.counter -= 1 } }) {
+                    Image(systemName: "minus.circle.fill")
+                        .font(.largeTitle)
+                }
+                Text("\(viewModel.counter)")
+                    .font(Typography.heading(36))
+                Button(action: { viewModel.counter += 1 }) {
+                    Image(systemName: "plus.circle.fill")
+                        .font(.largeTitle)
+                }
+            }
+            .padding(Spacing.m)
+
+            HStack {
+                ForEach(ActivityType.allCases, id: \.self) { type in
+                    Text(label(for: type))
+                        .font(Typography.caption())
+                        .padding(.horizontal, Spacing.m)
+                        .padding(.vertical, Spacing.s)
+                        .background(viewModel.selectedActivity == type ? AppColor.primary : AppColor.secondary.opacity(0.3))
+                        .foregroundStyle(viewModel.selectedActivity == type ? Color.white : AppColor.textPrimary)
+                        .clipShape(Capsule())
+                        .onTapGesture { viewModel.selectedActivity = type }
+                }
+            }
+
+            Toggle("Credit Hour", isOn: $viewModel.isCreditHour)
+                .padding(.horizontal, Spacing.m)
+
+            Picker("Companion", selection: $viewModel.selectedCompanion) {
+                ForEach(CompanionType.allCases, id: \.self) { companion in
+                    Text(label(for: companion)).tag(companion)
+                }
+            }
+            .pickerStyle(.segmented)
+            .padding(.horizontal, Spacing.m)
+
+            TextField("Notes", text: $viewModel.notes, axis: .vertical)
+                .textFieldStyle(.roundedBorder)
+                .padding(.horizontal, Spacing.m)
+
+            Text(viewModel.timeString)
+                .font(Typography.heading(36))
+                .padding(.top, Spacing.l)
+
+            Button(viewModel.isRunning ? "Stop" : "Start") {
+                if viewModel.isRunning {
+                    viewModel.stop(context: context)
+                } else {
+                    viewModel.start()
+                }
+            }
+            .frame(maxWidth: .infinity)
+            .padding()
+            .background(AppColor.primary)
+            .foregroundColor(.white)
+            .cornerRadius(8)
+            .padding(.horizontal, Spacing.m)
+        }
+        .padding(.vertical, Spacing.l)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(AppColor.background)
+    }
+
+    private func label(for type: ActivityType) -> String {
+        switch type {
+        case .study: return "Study"
+        case .breakTime: return "Break"
+        case .meeting: return "Meeting"
+        case .other: return "Other"
+        }
+    }
+
+    private func label(for companion: CompanionType) -> String {
+        switch companion {
+        case .solo: return "Solo"
+        case .friend: return "Friend"
+        case .group: return "Group"
+        }
+    }
+}
+
+#Preview {
+    StartSessionView()
+}
+

--- a/Industrious/Persistence.swift
+++ b/Industrious/Persistence.swift
@@ -20,6 +20,9 @@ struct PersistenceController {
             session.start = Date()
             session.end = Date()
             session.activityType = .study
+            session.isCreditHour = false
+            session.companion = .solo
+            session.notes = ""
         }
         do {
             try viewContext.save()


### PR DESCRIPTION
## Summary
- add CompanionType enum and extend Session entity with credit-hour, companion, and notes fields
- implement SessionViewModel with timer logic and persistence
- create StartSessionView with activity chips, counter controls, and session controls

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68b9035bc1b4832e83cf1df1ef2c23e2