### PR TITLE
Add credit minutes and day-off logging with role-based limits

### DIFF
--- a/Industrious/Industrious.xcdatamodeld/Industrious.xcdatamodel/contents
+++ b/Industrious/Industrious.xcdatamodeld/Industrious.xcdatamodel/contents
@@ -11,6 +11,8 @@
         <attribute name="isCreditHour" optional="NO" attributeType="Boolean" usesScalarValueType="YES"/>
         <attribute name="companionRaw" optional="NO" attributeType="String" usesScalarValueType="NO"/>
         <attribute name="notes" optional="YES" attributeType="String" usesScalarValueType="NO"/>
+        <attribute name="creditMinutes" optional="NO" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="assignmentTag" optional="YES" attributeType="String" usesScalarValueType="NO"/>
         <relationship name="study" optional="YES" toMany="NO" deletionRule="Nullify" destinationEntity="Study" inverseName="sessions" inverseEntity="Study"/>
     </entity>
     <entity name="CounterEntry" representedClassName="CounterEntry" syncable="YES" codeGenerationType="class">
@@ -27,6 +29,7 @@
     <entity name="DayOff" representedClassName="DayOff" syncable="YES" codeGenerationType="class">
         <attribute name="id" optional="NO" attributeType="UUID" usesScalarValueType="NO"/>
         <attribute name="date" optional="NO" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="isConvention" optional="NO" attributeType="Boolean" defaultValueString="0" usesScalarValueType="YES"/>
     </entity>
     <entity name="Goal" representedClassName="Goal" syncable="YES" codeGenerationType="class">
         <attribute name="id" optional="NO" attributeType="UUID" usesScalarValueType="NO"/>

--- a/Industrious/Models/Entities.swift
+++ b/Industrious/Models/Entities.swift
@@ -10,6 +10,8 @@ public class Session: NSManagedObject {
     @NSManaged public var isCreditHour: Bool
     @NSManaged public var companionRaw: String
     @NSManaged public var notes: String?
+    @NSManaged public var creditMinutes: Int64
+    @NSManaged public var assignmentTag: String?
     @NSManaged public var study: Study?
 
     public var activityType: ActivityType {
@@ -69,6 +71,7 @@ extension Study {
 public class DayOff: NSManagedObject {
     @NSManaged public var id: UUID
     @NSManaged public var date: Date
+    @NSManaged public var isConvention: Bool
 }
 
 extension DayOff {

--- a/Industrious/Models/Enums.swift
+++ b/Industrious/Models/Enums.swift
@@ -19,3 +19,32 @@ enum CompanionType: String, CaseIterable, Codable {
     case group
 }
 
+enum Role: String, CaseIterable, Codable {
+    case publisher
+    case pioneer
+
+    var displayName: String {
+        switch self {
+        case .publisher: "Publisher"
+        case .pioneer: "Pioneer"
+        }
+    }
+
+    var creditAllowance: Int {
+        switch self {
+        case .publisher: 0
+        case .pioneer: 60
+        }
+    }
+
+    var dayOffAllowance: Int {
+        switch self {
+        case .publisher: 0
+        case .pioneer: 3
+        }
+    }
+
+    var allowsCredit: Bool { creditAllowance > 0 }
+    var allowsDaysOff: Bool { dayOffAllowance > 0 }
+}
+

--- a/Industrious/Models/MigrationHelpers.swift
+++ b/Industrious/Models/MigrationHelpers.swift
@@ -21,6 +21,8 @@ struct MigrationHelper {
             session.isCreditHour = false
             session.companion = .solo
             session.notes = nil
+            session.creditMinutes = 0
+            session.assignmentTag = nil
             context.delete(item)
         }
         try context.save()

--- a/Industrious/Modules/Planner/DayOffLoggingView.swift
+++ b/Industrious/Modules/Planner/DayOffLoggingView.swift
@@ -1,0 +1,75 @@
+import SwiftUI
+import CoreData
+
+struct DayOffLoggingView: View {
+    @Environment(\.managedObjectContext) private var context
+    @FetchRequest(
+        entity: DayOff.entity(),
+        sortDescriptors: [NSSortDescriptor(keyPath: \DayOff.date, ascending: false)]
+    ) private var daysOff: FetchedResults<DayOff>
+
+    @State private var selectedRole: Role = .publisher
+
+    private var dayOffCount: Int {
+        daysOff.filter { !$0.isConvention }.count
+    }
+
+    var body: some View {
+        VStack {
+            Picker("Role", selection: $selectedRole) {
+                ForEach(Role.allCases, id: \.self) { role in
+                    Text(role.displayName).tag(role)
+                }
+            }
+            .pickerStyle(.segmented)
+            .padding()
+
+            if selectedRole.allowsDaysOff {
+                HStack {
+                    Button("Log Day Off") { addDayOff(convention: false) }
+                    Button("Log Convention Day") { addDayOff(convention: true) }
+                }
+                .padding()
+
+                if dayOffCount > selectedRole.dayOffAllowance {
+                    Text("Day-off allowance exceeded")
+                        .foregroundColor(.orange)
+                }
+            } else {
+                Button("Log Convention Day") { addDayOff(convention: true) }
+                    .padding()
+            }
+
+            List {
+                ForEach(daysOff, id: \.objectID) { day in
+                    HStack {
+                        Text(day.date, style: .date)
+                        if day.isConvention {
+                            Spacer()
+                            Text("Convention")
+                                .foregroundColor(.secondary)
+                        }
+                    }
+                }
+                .onDelete(perform: deleteDays)
+            }
+        }
+    }
+
+    private func addDayOff(convention: Bool) {
+        let entry = DayOff(context: context)
+        entry.id = UUID()
+        entry.date = Date()
+        entry.isConvention = convention
+        try? context.save()
+    }
+
+    private func deleteDays(at offsets: IndexSet) {
+        offsets.map { daysOff[$0] }.forEach(context.delete)
+        try? context.save()
+    }
+}
+
+#Preview {
+    DayOffLoggingView()
+}

--- a/Industrious/Modules/Planner/PlannerView.swift
+++ b/Industrious/Modules/Planner/PlannerView.swift
@@ -2,10 +2,7 @@ import SwiftUI
 
 struct PlannerView: View {
     var body: some View {
-        Text("Planner")
-            .font(Typography.heading())
-            .foregroundStyle(AppColor.textPrimary)
-            .padding(Spacing.m)
+        DayOffLoggingView()
             .frame(maxWidth: .infinity, maxHeight: .infinity)
             .background(AppColor.background)
     }

--- a/Industrious/Modules/Sessions/SessionViewModel.swift
+++ b/Industrious/Modules/Sessions/SessionViewModel.swift
@@ -5,8 +5,10 @@ import CoreData
 class SessionViewModel: ObservableObject {
     @Published var selectedActivity: ActivityType = .study
     @Published var isCreditHour: Bool = false
+    @Published var selectedRole: Role = .publisher
     @Published var selectedCompanion: CompanionType = .solo
     @Published var notes: String = ""
+    @Published var assignmentTag: String = ""
     @Published var elapsed: TimeInterval = 0
     @Published var isRunning: Bool = false
     @Published var counter: Int = 0
@@ -36,6 +38,8 @@ class SessionViewModel: ObservableObject {
         session.end = endDate
         session.activityType = selectedActivity
         session.isCreditHour = isCreditHour
+        session.creditMinutes = Int64(isCreditHour ? counter : 0)
+        session.assignmentTag = assignmentTag.isEmpty ? nil : assignmentTag
         session.companion = selectedCompanion
         session.notes = notes.isEmpty ? nil : notes
 

--- a/Industrious/Modules/Sessions/StartSessionView.swift
+++ b/Industrious/Modules/Sessions/StartSessionView.swift
@@ -6,19 +6,45 @@ struct StartSessionView: View {
 
     var body: some View {
         VStack(spacing: Spacing.l) {
-            HStack(spacing: Spacing.l) {
-                Button(action: { if viewModel.counter > 0 { viewModel.counter -= 1 } }) {
-                    Image(systemName: "minus.circle.fill")
-                        .font(.largeTitle)
-                }
-                Text("\(viewModel.counter)")
-                    .font(Typography.heading(36))
-                Button(action: { viewModel.counter += 1 }) {
-                    Image(systemName: "plus.circle.fill")
-                        .font(.largeTitle)
+            Picker("Role", selection: $viewModel.selectedRole) {
+                ForEach(Role.allCases, id: \.self) { role in
+                    Text(role.displayName).tag(role)
                 }
             }
-            .padding(Spacing.m)
+            .pickerStyle(.segmented)
+            .padding(.horizontal, Spacing.m)
+
+            if viewModel.selectedRole.allowsCredit {
+                Toggle("Credit Hour", isOn: $viewModel.isCreditHour)
+                    .padding(.horizontal, Spacing.m)
+
+                if viewModel.isCreditHour {
+                    HStack(spacing: Spacing.l) {
+                        Button(action: { if viewModel.counter > 0 { viewModel.counter -= 1 } }) {
+                            Image(systemName: "minus.circle.fill")
+                                .font(.largeTitle)
+                        }
+                        Text("\(viewModel.counter)")
+                            .font(Typography.heading(36))
+                        Button(action: { viewModel.counter += 1 }) {
+                            Image(systemName: "plus.circle.fill")
+                                .font(.largeTitle)
+                        }
+                    }
+                    .padding(Spacing.m)
+
+                    if viewModel.counter > viewModel.selectedRole.creditAllowance {
+                        Text("Credit minutes exceed allowance")
+                            .font(Typography.caption())
+                            .foregroundColor(.orange)
+                            .padding(.horizontal, Spacing.m)
+                    }
+
+                    TextField("Assignment Tag", text: $viewModel.assignmentTag)
+                        .textFieldStyle(.roundedBorder)
+                        .padding(.horizontal, Spacing.m)
+                }
+            }
 
             HStack {
                 ForEach(ActivityType.allCases, id: \.self) { type in
@@ -32,9 +58,6 @@ struct StartSessionView: View {
                         .onTapGesture { viewModel.selectedActivity = type }
                 }
             }
-
-            Toggle("Credit Hour", isOn: $viewModel.isCreditHour)
-                .padding(.horizontal, Spacing.m)
 
             Picker("Companion", selection: $viewModel.selectedCompanion) {
                 ForEach(CompanionType.allCases, id: \.self) { companion in

--- a/Industrious/Persistence.swift
+++ b/Industrious/Persistence.swift
@@ -23,6 +23,8 @@ struct PersistenceController {
             session.isCreditHour = false
             session.companion = .solo
             session.notes = ""
+            session.creditMinutes = 0
+            session.assignmentTag = nil
         }
         do {
             try viewContext.save()


### PR DESCRIPTION
## Summary
- track credit minutes and assignment tags on sessions
- log days off and convention days with role-based allowances
- filter session and day-off UI by role with soft warnings when limits exceeded

## Testing
- `swift test` *(fails: Could not find Package.swift in this directory or any of its parent directories.)*


------
https://chatgpt.com/codex/tasks/task_e_68ba31ad5674832ea14a4b649f5a6eb3