### PR TITLE
Add counter aggregation and controls

### DIFF
--- a/Industrious/Models/CountersAggregator.swift
+++ b/Industrious/Models/CountersAggregator.swift
@@ -1,0 +1,22 @@
+import Foundation
+import CoreData
+
+struct CountersAggregator {
+    static func monthlyTotals(context: NSManagedObjectContext, kind: CounterKind? = nil) throws -> [MonthKey: Int64] {
+        let request: NSFetchRequest<CounterEntry> = CounterEntry.fetchRequest()
+        if let kind = kind {
+            request.predicate = NSPredicate(format: "kindRaw == %@", kind.rawValue)
+        }
+        let entries = try context.fetch(request)
+        var result: [MonthKey: Int64] = [:]
+        let calendar = Calendar.current
+        for entry in entries {
+            let components = calendar.dateComponents([.year, .month], from: entry.date)
+            guard let year = components.year, let month = components.month else { continue }
+            let key = MonthKey(year: year, month: month)
+            result[key, default: 0] += entry.value
+        }
+        return result
+    }
+}
+

--- a/Industrious/Modules/Dashboard/DashboardView.swift
+++ b/Industrious/Modules/Dashboard/DashboardView.swift
@@ -1,13 +1,43 @@
 import SwiftUI
+import CoreData
 
 struct DashboardView: View {
+    @Environment(\.managedObjectContext) private var context
+    @State private var totals: [CounterKind: Int64] = [:]
+
     var body: some View {
-        Text("Dashboard")
-            .font(Typography.heading())
-            .foregroundStyle(AppColor.textPrimary)
-            .padding(Spacing.m)
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
-            .background(AppColor.background)
+        VStack(alignment: .leading, spacing: Spacing.m) {
+            Text("Dashboard")
+                .font(Typography.heading())
+                .foregroundStyle(AppColor.textPrimary)
+                .padding(Spacing.m)
+
+            ForEach(CounterKind.allCases, id: \.self) { kind in
+                HStack {
+                    Text(kind.rawValue.capitalized)
+                    Spacer()
+                    Text("\(totals[kind] ?? 0)")
+                }
+                .padding(.horizontal, Spacing.m)
+            }
+            Spacer()
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(AppColor.background)
+        .onAppear(perform: load)
+    }
+
+    private func load() {
+        let calendar = Calendar.current
+        let comps = calendar.dateComponents([.year, .month], from: Date())
+        guard let year = comps.year, let month = comps.month else { return }
+        let key = MonthKey(year: year, month: month)
+        var result: [CounterKind: Int64] = [:]
+        for kind in CounterKind.allCases {
+            let data = (try? CountersAggregator.monthlyTotals(context: context, kind: kind)) ?? [:]
+            result[kind] = data[key] ?? 0
+        }
+        totals = result
     }
 }
 

--- a/Industrious/Modules/History/HistoryView.swift
+++ b/Industrious/Modules/History/HistoryView.swift
@@ -1,13 +1,39 @@
 import SwiftUI
+import CoreData
 
 struct HistoryView: View {
+    @Environment(\.managedObjectContext) private var context
+    @State private var totals: [MonthKey: Int64] = [:]
+
     var body: some View {
-        Text("History")
-            .font(Typography.heading())
-            .foregroundStyle(AppColor.textPrimary)
-            .padding(Spacing.m)
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
-            .background(AppColor.background)
+        List(sortedKeys, id: \.self) { key in
+            HStack {
+                Text("\(monthName(key.month)) \(key.year)")
+                Spacer()
+                Text("\(totals[key] ?? 0)")
+            }
+        }
+        .listStyle(.plain)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(AppColor.background)
+        .onAppear(perform: load)
+    }
+
+    private var sortedKeys: [MonthKey] {
+        totals.keys.sorted { a, b in
+            if a.year == b.year { return a.month > b.month }
+            return a.year > b.year
+        }
+    }
+
+    private func load() {
+        totals = (try? CountersAggregator.monthlyTotals(context: context)) ?? [:]
+    }
+
+    private func monthName(_ month: Int) -> String {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "MMMM"
+        return formatter.monthSymbols[month - 1]
     }
 }
 

--- a/Industrious/Modules/Planner/CounterControlsView.swift
+++ b/Industrious/Modules/Planner/CounterControlsView.swift
@@ -1,0 +1,53 @@
+import SwiftUI
+import CoreData
+
+struct CounterControlsView: View {
+    @Environment(\.managedObjectContext) private var context
+    let kind: CounterKind
+    @FetchRequest private var entries: FetchedResults<CounterEntry>
+
+    init(kind: CounterKind) {
+        self.kind = kind
+        let calendar = Calendar.current
+        let startOfMonth = calendar.date(from: calendar.dateComponents([.year, .month], from: Date()))!
+        let endOfMonth = calendar.date(byAdding: DateComponents(month: 1, day: 0), to: startOfMonth)!
+        _entries = FetchRequest(
+            entity: CounterEntry.entity(),
+            sortDescriptors: [],
+            predicate: NSPredicate(format: "kindRaw == %@ AND date >= %@ AND date < %@", kind.rawValue, startOfMonth as NSDate, endOfMonth as NSDate)
+        )
+    }
+
+    private var total: Int64 {
+        entries.reduce(0) { $0 + $1.value }
+    }
+
+    var body: some View {
+        HStack(spacing: Spacing.l) {
+            Button(action: { add(value: -1) }) {
+                Image(systemName: "minus.circle.fill")
+                    .font(.largeTitle)
+            }
+            Text("\(total)")
+                .font(Typography.heading(36))
+            Button(action: { add(value: 1) }) {
+                Image(systemName: "plus.circle.fill")
+                    .font(.largeTitle)
+            }
+        }
+        .padding(Spacing.m)
+    }
+
+    private func add(value: Int64) {
+        let entry = CounterEntry(context: context)
+        entry.id = UUID()
+        entry.date = Date()
+        entry.kind = kind
+        entry.value = value
+        try? context.save()
+    }
+}
+
+#Preview {
+    CounterControlsView(kind: .session)
+}

--- a/Industrious/Modules/Planner/PlannerView.swift
+++ b/Industrious/Modules/Planner/PlannerView.swift
@@ -2,9 +2,21 @@ import SwiftUI
 
 struct PlannerView: View {
     var body: some View {
-        DayOffLoggingView()
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
-            .background(AppColor.background)
+        VStack {
+            ForEach(CounterKind.allCases, id: \.self) { kind in
+                HStack {
+                    Text(kind.rawValue.capitalized)
+                    Spacer()
+                    CounterControlsView(kind: kind)
+                }
+                .padding(.horizontal, Spacing.m)
+            }
+            Divider()
+                .padding(.vertical, Spacing.m)
+            DayOffLoggingView()
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(AppColor.background)
     }
 }
 


### PR DESCRIPTION
## Summary
- add `CountersAggregator` for monthly counter totals
- expose increment/decrement counter controls in planner
- display monthly aggregated counters on dashboard and history views

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68ba3313cb7c832ebbb6002bb2f206be