### PR TITLE
Add study management views with reminders and session integration

### DIFF
--- a/Industrious/Industrious.xcdatamodeld/Industrious.xcdatamodel/contents
+++ b/Industrious/Industrious.xcdatamodeld/Industrious.xcdatamodel/contents
@@ -24,6 +24,7 @@
     <entity name="Study" representedClassName="Study" syncable="YES" codeGenerationType="class">
         <attribute name="id" optional="NO" attributeType="UUID" usesScalarValueType="NO"/>
         <attribute name="title" optional="NO" attributeType="String" usesScalarValueType="NO"/>
+        <attribute name="nextVisit" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
         <relationship name="sessions" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Session" inverseName="study" inverseEntity="Session"/>
     </entity>
     <entity name="DayOff" representedClassName="DayOff" syncable="YES" codeGenerationType="class">

--- a/Industrious/Models/Entities.swift
+++ b/Industrious/Models/Entities.swift
@@ -55,6 +55,7 @@ public class Study: NSManagedObject {
     @NSManaged public var id: UUID
     @NSManaged public var title: String
     @NSManaged public var sessions: Set<Session>?
+    @NSManaged public var nextVisit: Date?
 
     public var sessionsArray: [Session] {
         sessions?.sorted { $0.start < $1.start } ?? []

--- a/Industrious/Modules/Sessions/SessionViewModel.swift
+++ b/Industrious/Modules/Sessions/SessionViewModel.swift
@@ -12,9 +12,14 @@ class SessionViewModel: ObservableObject {
     @Published var elapsed: TimeInterval = 0
     @Published var isRunning: Bool = false
     @Published var counter: Int = 0
+    @Published var selectedStudy: Study?
 
     private var timer: Timer?
     private var startDate: Date?
+
+    init(study: Study? = nil) {
+        self.selectedStudy = study
+    }
 
     func start() {
         startDate = Date()
@@ -42,6 +47,7 @@ class SessionViewModel: ObservableObject {
         session.assignmentTag = assignmentTag.isEmpty ? nil : assignmentTag
         session.companion = selectedCompanion
         session.notes = notes.isEmpty ? nil : notes
+        session.study = selectedStudy
 
         do {
             try context.save()

--- a/Industrious/Modules/Sessions/StartSessionView.swift
+++ b/Industrious/Modules/Sessions/StartSessionView.swift
@@ -1,8 +1,14 @@
 import SwiftUI
+import CoreData
 
 struct StartSessionView: View {
-    @StateObject private var viewModel = SessionViewModel()
+    @StateObject private var viewModel: SessionViewModel
     @Environment(\.managedObjectContext) private var context
+    @State private var showingStudyPicker = false
+
+    init(study: Study? = nil) {
+        _viewModel = StateObject(wrappedValue: SessionViewModel(study: study))
+    }
 
     var body: some View {
         VStack(spacing: Spacing.l) {
@@ -66,6 +72,21 @@ struct StartSessionView: View {
             }
             .pickerStyle(.segmented)
             .padding(.horizontal, Spacing.m)
+
+            Button(action: { showingStudyPicker = true }) {
+                HStack {
+                    Text(viewModel.selectedStudy?.title ?? "Select Study")
+                        .foregroundStyle(AppColor.textPrimary)
+                    Spacer()
+                    Image(systemName: "chevron.right")
+                        .foregroundStyle(AppColor.secondary)
+                }
+                .padding(.horizontal, Spacing.m)
+            }
+            .sheet(isPresented: $showingStudyPicker) {
+                StudyPicker(selection: $viewModel.selectedStudy)
+                    .environment(\.managedObjectContext, context)
+            }
 
             TextField("Notes", text: $viewModel.notes, axis: .vertical)
                 .textFieldStyle(.roundedBorder)

--- a/Industrious/Modules/Studies/StudiesView.swift
+++ b/Industrious/Modules/Studies/StudiesView.swift
@@ -1,16 +1,51 @@
 import SwiftUI
+import CoreData
 
 struct StudiesView: View {
+    @Environment(\.managedObjectContext) private var context
+    @FetchRequest(sortDescriptors: [NSSortDescriptor(keyPath: \Study.title, ascending: true)])
+    private var studies: FetchedResults<Study>
+    @State private var showingAdd = false
+    @State private var newTitle = ""
+
     var body: some View {
-        Text("Studies")
-            .font(Typography.heading())
-            .foregroundStyle(AppColor.textPrimary)
-            .padding(Spacing.m)
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
-            .background(AppColor.background)
+        NavigationStack {
+            List {
+                ForEach(studies, id: \.id) { study in
+                    NavigationLink(study.title) {
+                        StudyDetailView(study: study)
+                    }
+                }
+            }
+            .navigationTitle("Studies")
+            .toolbar {
+                ToolbarItem(placement: .primaryAction) {
+                    Button(action: { showingAdd = true }) {
+                        Image(systemName: "plus")
+                    }
+                }
+            }
+            .sheet(isPresented: $showingAdd) {
+                NavigationStack {
+                    Form {
+                        TextField("Title", text: $newTitle)
+                        Button("Add") {
+                            let study = Study(context: context)
+                            study.id = UUID()
+                            study.title = newTitle
+                            try? context.save()
+                            newTitle = ""
+                            showingAdd = false
+                        }
+                    }
+                    .navigationTitle("New Study")
+                }
+            }
+        }
     }
 }
 
 #Preview {
     StudiesView()
+        .environment(\.managedObjectContext, PersistenceController.preview.container.viewContext)
 }

--- a/Industrious/Modules/Studies/StudyDetailView.swift
+++ b/Industrious/Modules/Studies/StudyDetailView.swift
@@ -1,0 +1,60 @@
+import SwiftUI
+import CoreData
+import UserNotifications
+
+struct StudyDetailView: View {
+    @ObservedObject var study: Study
+    @Environment(\.managedObjectContext) private var context
+    @State private var showingStart = false
+
+    var body: some View {
+        List {
+            Section("Reminder") {
+                DatePicker("Next Visit", selection: Binding(
+                    get: { study.nextVisit ?? Date() },
+                    set: { newValue in
+                        study.nextVisit = newValue
+                        try? context.save()
+                        NotificationManager.shared.schedule(study: study)
+                    }
+                ), displayedComponents: [.date, .hourAndMinute])
+                if study.nextVisit != nil {
+                    Button("Clear Reminder") {
+                        study.nextVisit = nil
+                        try? context.save()
+                        UNUserNotificationCenter.current().removePendingNotificationRequests(withIdentifiers: [study.notificationID])
+                    }
+                }
+            }
+            Section("Sessions") {
+                ForEach(study.sessionsArray, id: \.id) { session in
+                    VStack(alignment: .leading) {
+                        Text(session.start, style: .date)
+                        Text(session.start, style: .time)
+                            .font(Typography.caption())
+                    }
+                }
+            }
+        }
+        .navigationTitle(study.title)
+        .toolbar {
+            ToolbarItem(placement: .primaryAction) {
+                Button("Start") { showingStart = true }
+            }
+        }
+        .sheet(isPresented: $showingStart) {
+            StartSessionView(study: study)
+        }
+    }
+}
+
+struct StudyDetailView_Previews: PreviewProvider {
+    static var previews: some View {
+        let context = PersistenceController.preview.container.viewContext
+        let study = Study(context: context)
+        study.id = UUID()
+        study.title = "Preview"
+        return StudyDetailView(study: study)
+            .environment(\.managedObjectContext, context)
+    }
+}

--- a/Industrious/Modules/Studies/StudyPicker.swift
+++ b/Industrious/Modules/Studies/StudyPicker.swift
@@ -1,0 +1,36 @@
+import SwiftUI
+import CoreData
+
+struct StudyPicker: View {
+    @FetchRequest(sortDescriptors: [NSSortDescriptor(keyPath: \Study.title, ascending: true)])
+    private var studies: FetchedResults<Study>
+    @Binding var selection: Study?
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        NavigationStack {
+            List(studies, id: \.id) { study in
+                Button(action: {
+                    selection = study
+                    dismiss()
+                }) {
+                    HStack {
+                        Text(study.title)
+                        if selection == study {
+                            Spacer()
+                            Image(systemName: "checkmark")
+                        }
+                    }
+                }
+            }
+            .navigationTitle("Studies")
+        }
+    }
+}
+
+struct StudyPicker_Previews: PreviewProvider {
+    static var previews: some View {
+        StudyPicker(selection: .constant(nil))
+            .environment(\.managedObjectContext, PersistenceController.preview.container.viewContext)
+    }
+}

--- a/Industrious/NotificationManager.swift
+++ b/Industrious/NotificationManager.swift
@@ -1,0 +1,27 @@
+import Foundation
+import UserNotifications
+
+class NotificationManager {
+    static let shared = NotificationManager()
+    private init() { }
+
+    func schedule(study: Study) {
+        guard let date = study.nextVisit else { return }
+        let center = UNUserNotificationCenter.current()
+        center.requestAuthorization(options: [.alert, .sound, .badge]) { granted, _ in
+            guard granted else { return }
+            let content = UNMutableNotificationContent()
+            content.title = "Next Visit"
+            content.body = "Visit \(study.title)"
+            let comps = Calendar.current.dateComponents([.year, .month, .day, .hour, .minute], from: date)
+            let trigger = UNCalendarNotificationTrigger(dateMatching: comps, repeats: false)
+            let request = UNNotificationRequest(identifier: study.notificationID, content: content, trigger: trigger)
+            center.removePendingNotificationRequests(withIdentifiers: [study.notificationID])
+            center.add(request)
+        }
+    }
+}
+
+extension Study {
+    var notificationID: String { "study-\(id.uuidString)" }
+}


### PR DESCRIPTION
## Summary
- add next-visit tracking to Study entity and persistent model
- implement study list & detail views with reminder scheduling
- allow selecting studies when starting sessions and launch sessions from a study
- schedule local notifications for upcoming visits

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68ba347d4a58832e896031e17207ec0d