### PR TITLE
Add goal periods and week planner with reminders

### DIFF
--- a/Industrious/Industrious.xcdatamodeld/Industrious.xcdatamodel/contents
+++ b/Industrious/Industrious.xcdatamodeld/Industrious.xcdatamodel/contents
@@ -36,6 +36,8 @@
         <attribute name="id" optional="NO" attributeType="UUID" usesScalarValueType="NO"/>
         <attribute name="title" optional="NO" attributeType="String" usesScalarValueType="NO"/>
         <attribute name="target" optional="NO" attributeType="Double" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="periodRaw" optional="NO" attributeType="String" usesScalarValueType="NO"/>
+        <attribute name="progress" optional="NO" attributeType="Double" defaultValueString="0" usesScalarValueType="YES"/>
     </entity>
     <entity name="Preference" representedClassName="Preference" syncable="YES" codeGenerationType="class">
         <attribute name="key" optional="NO" attributeType="String" usesScalarValueType="NO"/>

--- a/Industrious/Models/Entities.swift
+++ b/Industrious/Models/Entities.swift
@@ -86,6 +86,13 @@ public class Goal: NSManagedObject {
     @NSManaged public var id: UUID
     @NSManaged public var title: String
     @NSManaged public var target: Double
+    @NSManaged public var periodRaw: String
+    @NSManaged public var progress: Double
+
+    public var period: GoalPeriod {
+        get { GoalPeriod(rawValue: periodRaw) ?? .weekly }
+        set { periodRaw = newValue.rawValue }
+    }
 }
 
 extension Goal {

--- a/Industrious/Models/Enums.swift
+++ b/Industrious/Models/Enums.swift
@@ -13,6 +13,12 @@ enum CounterKind: String, CaseIterable, Codable {
     case goal
 }
 
+enum GoalPeriod: String, CaseIterable, Codable {
+    case weekly
+    case monthly
+    case counter
+}
+
 enum CompanionType: String, CaseIterable, Codable {
     case solo
     case friend

--- a/Industrious/Models/PlannedSession.swift
+++ b/Industrious/Models/PlannedSession.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+struct PlannedSession: Identifiable, Codable {
+    var id = UUID()
+    var start: Date
+    var activity: ActivityType
+}

--- a/Industrious/Modules/Planner/PlannerView.swift
+++ b/Industrious/Modules/Planner/PlannerView.swift
@@ -2,21 +2,28 @@ import SwiftUI
 
 struct PlannerView: View {
     var body: some View {
-        VStack {
-            ForEach(CounterKind.allCases, id: \.self) { kind in
-                HStack {
-                    Text(kind.rawValue.capitalized)
-                    Spacer()
-                    CounterControlsView(kind: kind)
+        NavigationStack {
+            VStack {
+                ForEach(CounterKind.allCases, id: \.self) { kind in
+                    HStack {
+                        Text(kind.rawValue.capitalized)
+                        Spacer()
+                        CounterControlsView(kind: kind)
+                    }
+                    .padding(.horizontal, Spacing.m)
                 }
-                .padding(.horizontal, Spacing.m)
+                Divider()
+                    .padding(.vertical, Spacing.m)
+                DayOffLoggingView()
+                NavigationLink("Week Planner") {
+                    WeekPlannerView()
+                }
+                .padding(.top, Spacing.l)
             }
-            Divider()
-                .padding(.vertical, Spacing.m)
-            DayOffLoggingView()
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .background(AppColor.background)
+            .navigationTitle("Planner")
         }
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .background(AppColor.background)
     }
 }
 

--- a/Industrious/Modules/Planner/WeekPlannerView.swift
+++ b/Industrious/Modules/Planner/WeekPlannerView.swift
@@ -1,0 +1,95 @@
+import SwiftUI
+
+struct WeekPlannerView: View {
+    @State private var sessions: [PlannedSession] = []
+    @State private var isAdding = false
+    @State private var newDate = Date()
+
+    var body: some View {
+        VStack(alignment: .leading) {
+            ForEach(currentWeek(), id: \.self) { day in
+                VStack(alignment: .leading) {
+                    Text(dayFormatter.string(from: day))
+                        .font(.headline)
+                    ForEach(sessions.filter { Calendar.current.isDate($0.start, inSameDayAs: day) }) { session in
+                        Text("\(timeFormatter.string(from: session.start)) \(session.activity.rawValue.capitalized)")
+                            .padding(4)
+                            .background(session.activity.color.opacity(0.2))
+                            .cornerRadius(4)
+                    }
+                }
+                .padding(.vertical, 4)
+                .onTapGesture {
+                    newDate = day
+                    isAdding = true
+                }
+            }
+        }
+        .padding()
+        .navigationTitle("Week Planner")
+        .sheet(isPresented: $isAdding) {
+            AddSessionView(date: newDate) { session in
+                sessions.append(session)
+                NotificationManager.shared.schedule(session: session)
+            }
+        }
+    }
+
+    private func currentWeek() -> [Date] {
+        let cal = Calendar.current
+        let start = cal.date(from: cal.dateComponents([.yearForWeekOfYear, .weekOfYear], from: Date()))!
+        return (0..<7).compactMap { cal.date(byAdding: .day, value: $0, to: start) }
+    }
+
+    private var dayFormatter: DateFormatter {
+        let df = DateFormatter()
+        df.dateFormat = "EEEE"
+        return df
+    }
+
+    private var timeFormatter: DateFormatter {
+        let df = DateFormatter()
+        df.timeStyle = .short
+        return df
+    }
+}
+
+struct AddSessionView: View {
+    var date: Date
+    var onAdd: (PlannedSession) -> Void
+    @Environment(\.dismiss) private var dismiss
+    @State private var time = Date()
+    @State private var activity: ActivityType = .study
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                DatePicker("Time", selection: $time, displayedComponents: .hourAndMinute)
+                Picker("Activity", selection: $activity) {
+                    ForEach(ActivityType.allCases, id: \.self) { type in
+                        Text(type.rawValue.capitalized).tag(type)
+                    }
+                }
+            }
+            .navigationTitle("New Session")
+            .toolbar {
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Add") {
+                        let start = Calendar.current.date(bySettingHour: Calendar.current.component(.hour, from: time), minute: Calendar.current.component(.minute, from: time), second: 0, of: date) ?? date
+                        onAdd(PlannedSession(start: start, activity: activity))
+                        dismiss()
+                    }
+                }
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { dismiss() }
+                }
+            }
+        }
+    }
+}
+
+#Preview {
+    NavigationStack {
+        WeekPlannerView()
+    }
+}

--- a/Industrious/NotificationManager.swift
+++ b/Industrious/NotificationManager.swift
@@ -20,6 +20,20 @@ class NotificationManager {
             center.add(request)
         }
     }
+
+    func schedule(session: PlannedSession) {
+        let center = UNUserNotificationCenter.current()
+        center.requestAuthorization(options: [.alert, .sound, .badge]) { granted, _ in
+            guard granted else { return }
+            let content = UNMutableNotificationContent()
+            content.title = "Planned Session"
+            content.body = session.activity.rawValue.capitalized
+            let comps = Calendar.current.dateComponents([.year, .month, .day, .hour, .minute], from: session.start)
+            let trigger = UNCalendarNotificationTrigger(dateMatching: comps, repeats: false)
+            let request = UNNotificationRequest(identifier: session.id.uuidString, content: content, trigger: trigger)
+            center.add(request)
+        }
+    }
 }
 
 extension Study {

--- a/Industrious/Shared/DesignSystem/ActivityType+Color.swift
+++ b/Industrious/Shared/DesignSystem/ActivityType+Color.swift
@@ -1,0 +1,12 @@
+import SwiftUI
+
+extension ActivityType {
+    var color: Color {
+        switch self {
+        case .study: return .blue
+        case .breakTime: return .green
+        case .meeting: return .orange
+        case .other: return .gray
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- extend `Goal` model with period and progress tracking
- add week planner UI with color-coded activities and tap-to-add sessions
- schedule notifications for planned sessions

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68ba53b115f0832e890fb17ecaf7d86c