### PR TITLE
Add unit/UI tests and sample data support

### DIFF
--- a/Industrious/Models/SampleData.swift
+++ b/Industrious/Models/SampleData.swift
@@ -1,0 +1,55 @@
+import Foundation
+import CoreData
+
+struct SampleData {
+    @discardableResult
+    static func insertSampleData(context: NSManagedObjectContext) -> ([Session], [CounterEntry]) {
+        let calendar = Calendar.current
+
+        let session1 = Session(context: context)
+        session1.id = UUID()
+        session1.start = calendar.date(from: DateComponents(year: 2024, month: 1, day: 10, hour: 9))!
+        session1.end = session1.start.addingTimeInterval(3600) // 1 hour
+        session1.activityType = .study
+        session1.companion = .solo
+        session1.isCreditHour = false
+        session1.creditMinutes = 0
+
+        let session2 = Session(context: context)
+        session2.id = UUID()
+        session2.start = calendar.date(from: DateComponents(year: 2024, month: 2, day: 5, hour: 10))!
+        session2.end = session2.start.addingTimeInterval(7200) // 2 hours
+        session2.activityType = .breakTime
+        session2.companion = .friend
+        session2.isCreditHour = false
+        session2.creditMinutes = 0
+
+        let entry1 = CounterEntry(context: context)
+        entry1.id = UUID()
+        entry1.date = calendar.date(from: DateComponents(year: 2024, month: 1, day: 15))!
+        entry1.kind = .session
+        entry1.value = 3
+
+        let entry2 = CounterEntry(context: context)
+        entry2.id = UUID()
+        entry2.date = calendar.date(from: DateComponents(year: 2024, month: 2, day: 20))!
+        entry2.kind = .session
+        entry2.value = 5
+
+        try? context.save()
+        return ([session1, session2], [entry1, entry2])
+    }
+
+    static var plannedSessions: [PlannedSession] {
+        let calendar = Calendar.current
+        return [
+            PlannedSession(start: calendar.date(from: DateComponents(year: 2024, month: 3, day: 1, hour: 9))!, activity: .study),
+            PlannedSession(start: calendar.date(from: DateComponents(year: 2024, month: 3, day: 2, hour: 10))!, activity: .meeting)
+        ]
+    }
+
+    static func seedPreview(context: NSManagedObjectContext) {
+        _ = insertSampleData(context: context)
+    }
+}
+

--- a/Industrious/Modules/Planner/WeekPlannerView.swift
+++ b/Industrious/Modules/Planner/WeekPlannerView.swift
@@ -1,9 +1,13 @@
 import SwiftUI
 
 struct WeekPlannerView: View {
-    @State private var sessions: [PlannedSession] = []
+    @State private var sessions: [PlannedSession]
     @State private var isAdding = false
     @State private var newDate = Date()
+
+    init(sessions: [PlannedSession] = []) {
+        _sessions = State(initialValue: sessions)
+    }
 
     var body: some View {
         VStack(alignment: .leading) {
@@ -90,6 +94,6 @@ struct AddSessionView: View {
 
 #Preview {
     NavigationStack {
-        WeekPlannerView()
+        WeekPlannerView(sessions: SampleData.plannedSessions)
     }
 }

--- a/Industrious/Persistence.swift
+++ b/Industrious/Persistence.swift
@@ -14,26 +14,7 @@ struct PersistenceController {
     static let preview: PersistenceController = {
         let result = PersistenceController(inMemory: true)
         let viewContext = result.container.viewContext
-        for _ in 0..<10 {
-            let session = Session(context: viewContext)
-            session.id = UUID()
-            session.start = Date()
-            session.end = Date()
-            session.activityType = .study
-            session.isCreditHour = false
-            session.companion = .solo
-            session.notes = ""
-            session.creditMinutes = 0
-            session.assignmentTag = nil
-        }
-        do {
-            try viewContext.save()
-        } catch {
-            // Replace this implementation with code to handle the error appropriately.
-            // fatalError() causes the application to generate a crash log and terminate. You should not use this function in a shipping application, although it may be useful during development.
-            let nsError = error as NSError
-            fatalError("Unresolved error \(nsError), \(nsError.userInfo)")
-        }
+        SampleData.seedPreview(context: viewContext)
         return result
     }()
 

--- a/IndustriousTests/AggregationTests.swift
+++ b/IndustriousTests/AggregationTests.swift
@@ -1,0 +1,26 @@
+import Testing
+@testable import Industrious
+import CoreData
+
+struct AggregationTests {
+    @MainActor
+    @Test func sessionDurationsByMonth() async throws {
+        let controller = PersistenceController(inMemory: true)
+        let context = controller.container.viewContext
+        SampleData.insertSampleData(context: context)
+        let result = try Aggregator.sessionDurationsByMonth(context: context)
+        #expect(result[MonthKey(year: 2024, month: 1)] == 3600)
+        #expect(result[MonthKey(year: 2024, month: 2)] == 7200)
+    }
+
+    @MainActor
+    @Test func counterTotalsByMonth() async throws {
+        let controller = PersistenceController(inMemory: true)
+        let context = controller.container.viewContext
+        SampleData.insertSampleData(context: context)
+        let result = try CountersAggregator.monthlyTotals(context: context, kind: .session)
+        #expect(result[MonthKey(year: 2024, month: 1)] == 3)
+        #expect(result[MonthKey(year: 2024, month: 2)] == 5)
+    }
+}
+

--- a/IndustriousTests/SessionViewModelTests.swift
+++ b/IndustriousTests/SessionViewModelTests.swift
@@ -1,0 +1,22 @@
+import Testing
+@testable import Industrious
+import CoreData
+
+struct SessionViewModelTests {
+    @MainActor
+    @Test func timerIncrements() async throws {
+        let vm = SessionViewModel()
+        vm.start()
+        try await Task.sleep(nanoseconds: 1_000_000_000)
+        vm.reset()
+        #expect(vm.elapsed >= 1)
+    }
+
+    @Test func counterUpdates() async throws {
+        let vm = SessionViewModel()
+        vm.counter = 0
+        vm.counter += 1
+        #expect(vm.counter == 1)
+    }
+}
+

--- a/IndustriousUITests/IndustriousUITests.swift
+++ b/IndustriousUITests/IndustriousUITests.swift
@@ -23,12 +23,38 @@ final class IndustriousUITests: XCTestCase {
     }
 
     @MainActor
-    func testExample() throws {
-        // UI tests must launch the application that they test.
+    func testSessionFlow() throws {
         let app = XCUIApplication()
         app.launch()
+        app.tabBars.buttons["Sessions"].tap()
+        app.buttons["Start Session"].tap()
+        app.buttons["Start"].tap()
+        app.buttons["Stop"].tap()
+    }
 
-        // Use XCTAssert and related functions to verify your tests produce the correct results.
+    @MainActor
+    func testPlannerNavigation() throws {
+        let app = XCUIApplication()
+        app.launch()
+        app.tabBars.buttons["Planner"].tap()
+        XCTAssertTrue(app.navigationBars["Planner"].exists)
+    }
+
+    @MainActor
+    func testExportFlow() throws {
+        let app = XCUIApplication()
+        app.launch()
+        app.tabBars.buttons["History"].tap()
+        app.cells.element(boundBy: 0).tap()
+        app.buttons["Export CSV"].tap()
+    }
+
+    @MainActor
+    func testSettingsNavigation() throws {
+        let app = XCUIApplication()
+        app.launch()
+        app.tabBars.buttons["Settings"].tap()
+        XCTAssertTrue(app.navigationBars["Settings"].exists)
     }
 
     @MainActor


### PR DESCRIPTION
## Summary
- add SampleData helper and wire into preview persistence
- expand WeekPlannerView to accept preview sessions
- create unit tests for session timer, counters, and aggregators
- add UI tests for session flow, planner, export, and settings

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68bba1324b04832ea99f18117f9c1998