### PR TITLE
Allow sessions to link multiple studies

### DIFF
--- a/Industrious/Industrious.xcdatamodeld/Industrious.xcdatamodel/contents
+++ b/Industrious/Industrious.xcdatamodeld/Industrious.xcdatamodel/contents
@@ -13,7 +13,7 @@
         <attribute name="notes" optional="YES" attributeType="String" usesScalarValueType="NO"/>
         <attribute name="creditMinutes" optional="NO" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="assignmentTag" optional="YES" attributeType="String" usesScalarValueType="NO"/>
-        <relationship name="study" optional="YES" toMany="NO" deletionRule="Nullify" destinationEntity="Study" inverseName="sessions" inverseEntity="Study"/>
+        <relationship name="studies" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Study" inverseName="sessions" inverseEntity="Study"/>
     </entity>
     <entity name="CounterEntry" representedClassName="CounterEntry" syncable="YES" codeGenerationType="class">
         <attribute name="id" optional="NO" attributeType="UUID" usesScalarValueType="NO"/>
@@ -25,7 +25,7 @@
         <attribute name="id" optional="NO" attributeType="UUID" usesScalarValueType="NO"/>
         <attribute name="title" optional="NO" attributeType="String" usesScalarValueType="NO"/>
         <attribute name="nextVisit" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
-        <relationship name="sessions" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Session" inverseName="study" inverseEntity="Session"/>
+        <relationship name="sessions" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Session" inverseName="studies" inverseEntity="Session"/>
     </entity>
     <entity name="DayOff" representedClassName="DayOff" syncable="YES" codeGenerationType="class">
         <attribute name="id" optional="NO" attributeType="UUID" usesScalarValueType="NO"/>

--- a/Industrious/Models/Entities.swift
+++ b/Industrious/Models/Entities.swift
@@ -12,7 +12,7 @@ public class Session: NSManagedObject {
     @NSManaged public var notes: String?
     @NSManaged public var creditMinutes: Int64
     @NSManaged public var assignmentTag: String?
-    @NSManaged public var study: Study?
+    @NSManaged public var studies: Set<Study>?
 
     public var activityType: ActivityType {
         get { ActivityType(rawValue: activityTypeRaw) ?? .study }

--- a/Industrious/Modules/Sessions/SessionViewModel.swift
+++ b/Industrious/Modules/Sessions/SessionViewModel.swift
@@ -12,13 +12,13 @@ class SessionViewModel: ObservableObject {
     @Published var elapsed: TimeInterval = 0
     @Published var isRunning: Bool = false
     @Published var counter: Int = 0
-    @Published var selectedStudy: Study?
+    @Published var selectedStudies: Set<Study> = []
 
     private var timer: Timer?
     private var startDate: Date?
 
-    init(study: Study? = nil) {
-        self.selectedStudy = study
+    init(studies: Set<Study> = []) {
+        self.selectedStudies = studies
     }
 
     func start() {
@@ -47,7 +47,7 @@ class SessionViewModel: ObservableObject {
         session.assignmentTag = assignmentTag.isEmpty ? nil : assignmentTag
         session.companion = selectedCompanion
         session.notes = notes.isEmpty ? nil : notes
-        session.study = selectedStudy
+        session.studies = selectedStudies.isEmpty ? nil : selectedStudies
 
         do {
             try context.save()

--- a/Industrious/Modules/Sessions/StartSessionView.swift
+++ b/Industrious/Modules/Sessions/StartSessionView.swift
@@ -9,7 +9,8 @@ struct StartSessionView: View {
     @State private var showingStudyPicker = false
 
     init(study: Study? = nil) {
-        _viewModel = StateObject(wrappedValue: SessionViewModel(study: study))
+        let initialStudies = study.map { Set([$0]) } ?? []
+        _viewModel = StateObject(wrappedValue: SessionViewModel(studies: initialStudies))
     }
 
     private func undoBinding<T>(_ keyPath: ReferenceWritableKeyPath<SessionViewModel, T>) -> Binding<T> {
@@ -123,7 +124,7 @@ struct StartSessionView: View {
 
             Button(action: { showingStudyPicker = true }) {
                 HStack {
-                    Text(viewModel.selectedStudy?.title ?? "Select Study")
+                    Text(viewModel.selectedStudies.isEmpty ? "Select Studies" : viewModel.selectedStudies.map { $0.title }.sorted().joined(separator: ", "))
                         .foregroundStyle(AppColor.textPrimary)
                     Spacer()
                     Image(systemName: "chevron.right")
@@ -133,7 +134,7 @@ struct StartSessionView: View {
                 .frame(minHeight: 44)
             }
             .sheet(isPresented: $showingStudyPicker) {
-                StudyPicker(selection: undoBinding(\.selectedStudy))
+                StudyPicker(selection: undoBinding(\.selectedStudies))
                     .environment(\.managedObjectContext, context)
             }
 

--- a/Industrious/Modules/Studies/StudyPicker.swift
+++ b/Industrious/Modules/Studies/StudyPicker.swift
@@ -4,19 +4,22 @@ import CoreData
 struct StudyPicker: View {
     @FetchRequest(sortDescriptors: [NSSortDescriptor(keyPath: \Study.title, ascending: true)])
     private var studies: FetchedResults<Study>
-    @Binding var selection: Study?
+    @Binding var selection: Set<Study>
     @Environment(\.dismiss) private var dismiss
 
     var body: some View {
         NavigationStack {
             List(studies, id: \.id) { study in
                 Button(action: {
-                    selection = study
-                    dismiss()
+                    if selection.contains(study) {
+                        selection.remove(study)
+                    } else {
+                        selection.insert(study)
+                    }
                 }) {
                     HStack {
                         Text(study.title)
-                        if selection == study {
+                        if selection.contains(study) {
                             Spacer()
                             Image(systemName: "checkmark")
                         }
@@ -24,13 +27,18 @@ struct StudyPicker: View {
                 }
             }
             .navigationTitle("Studies")
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Done") { dismiss() }
+                }
+            }
         }
     }
 }
 
 struct StudyPicker_Previews: PreviewProvider {
     static var previews: some View {
-        StudyPicker(selection: .constant(nil))
+        StudyPicker(selection: .constant([]))
             .environment(\.managedObjectContext, PersistenceController.preview.container.viewContext)
     }
 }


### PR DESCRIPTION
## Summary
- allow sessions to reference multiple studies via new `studies` relationship
- enable multi-select study picking for sessions
- persist chosen studies on session save

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68bba9926eac832e9f262963bedfc041