### PR TITLE
Use implementation-only CoreData imports

### DIFF
--- a/Industrious/IndustriousApp.swift
+++ b/Industrious/IndustriousApp.swift
@@ -6,8 +6,7 @@
 //
 
 import SwiftUI
-import CoreData
-
+@_implementationOnly import CoreData
 @main
 struct IndustriousApp: App {
     let persistenceController = PersistenceController.shared

--- a/Industrious/Models/Aggregation.swift
+++ b/Industrious/Models/Aggregation.swift
@@ -1,6 +1,5 @@
 import Foundation
-import CoreData
-
+@_implementationOnly import CoreData
 struct MonthKey: Hashable {
     let year: Int
     let month: Int

--- a/Industrious/Models/CountersAggregator.swift
+++ b/Industrious/Models/CountersAggregator.swift
@@ -1,6 +1,5 @@
 import Foundation
-import CoreData
-
+@_implementationOnly import CoreData
 struct CountersAggregator {
     static func monthlyTotals(context: NSManagedObjectContext, kind: CounterKind? = nil) throws -> [MonthKey: Int64] {
         let request: NSFetchRequest<CounterEntry> = CounterEntry.fetchRequest()

--- a/Industrious/Models/Entities.swift
+++ b/Industrious/Models/Entities.swift
@@ -1,6 +1,5 @@
 import Foundation
-import CoreData
-
+@_implementationOnly import CoreData
 @objc(Session)
 public class Session: NSManagedObject {
     @NSManaged public var id: UUID

--- a/Industrious/Models/MigrationHelpers.swift
+++ b/Industrious/Models/MigrationHelpers.swift
@@ -1,6 +1,5 @@
 import Foundation
-import CoreData
-
+@_implementationOnly import CoreData
 struct MigrationHelper {
     static func migrateLegacyItems(context: NSManagedObjectContext) throws {
         let request = NSFetchRequest<NSManagedObject>(entityName: "Item")

--- a/Industrious/Models/SampleData.swift
+++ b/Industrious/Models/SampleData.swift
@@ -1,6 +1,5 @@
 import Foundation
-import CoreData
-
+@_implementationOnly import CoreData
 struct SampleData {
     @discardableResult
     static func insertSampleData(context: NSManagedObjectContext) -> ([Session], [CounterEntry]) {

--- a/Industrious/Modules/Dashboard/DashboardComponents.swift
+++ b/Industrious/Modules/Dashboard/DashboardComponents.swift
@@ -1,6 +1,6 @@
 import SwiftUI
 import Charts
-import CoreData
+@_implementationOnly import CoreData
 
 struct DailyStat: Identifiable {
     let id = UUID()

--- a/Industrious/Modules/Dashboard/DashboardView.swift
+++ b/Industrious/Modules/Dashboard/DashboardView.swift
@@ -1,6 +1,5 @@
 import SwiftUI
-import CoreData
-
+@_implementationOnly import CoreData
 struct DashboardView: View {
     @Environment(\.managedObjectContext) private var context
     @State private var totals: [CounterKind: Int64] = [:]

--- a/Industrious/Modules/History/HistoryView.swift
+++ b/Industrious/Modules/History/HistoryView.swift
@@ -1,6 +1,5 @@
 import SwiftUI
-import CoreData
-
+@_implementationOnly import CoreData
 struct HistoryView: View {
     @Environment(\.managedObjectContext) private var context
     @State private var totals: [MonthKey: Int64] = [:]

--- a/Industrious/Modules/History/MonthDetailView.swift
+++ b/Industrious/Modules/History/MonthDetailView.swift
@@ -1,6 +1,5 @@
 import SwiftUI
-import CoreData
-
+@_implementationOnly import CoreData
 struct MonthDetailView: View {
     @Environment(\.managedObjectContext) private var context
     let month: Int

--- a/Industrious/Modules/Planner/CounterControlsView.swift
+++ b/Industrious/Modules/Planner/CounterControlsView.swift
@@ -1,6 +1,5 @@
 import SwiftUI
-import CoreData
-
+@_implementationOnly import CoreData
 struct CounterControlsView: View {
     @Environment(\.managedObjectContext) private var context
     let kind: CounterKind

--- a/Industrious/Modules/Planner/DayOffLoggingView.swift
+++ b/Industrious/Modules/Planner/DayOffLoggingView.swift
@@ -1,6 +1,5 @@
 import SwiftUI
-import CoreData
-
+@_implementationOnly import CoreData
 struct DayOffLoggingView: View {
     @Environment(\.managedObjectContext) private var context
     @FetchRequest(

--- a/Industrious/Modules/Sessions/SessionViewModel.swift
+++ b/Industrious/Modules/Sessions/SessionViewModel.swift
@@ -1,6 +1,5 @@
 import Foundation
-import CoreData
-
+@_implementationOnly import CoreData
 @MainActor
 class SessionViewModel: ObservableObject {
     @Published var selectedActivity: ActivityType = .study

--- a/Industrious/Modules/Sessions/StartSessionView.swift
+++ b/Industrious/Modules/Sessions/StartSessionView.swift
@@ -1,5 +1,5 @@
 import SwiftUI
-import CoreData
+@_implementationOnly import CoreData
 import UIKit
 
 struct StartSessionView: View {

--- a/Industrious/Modules/Studies/StudiesView.swift
+++ b/Industrious/Modules/Studies/StudiesView.swift
@@ -1,6 +1,5 @@
 import SwiftUI
-import CoreData
-
+@_implementationOnly import CoreData
 struct StudiesView: View {
     @Environment(\.managedObjectContext) private var context
     @FetchRequest(sortDescriptors: [NSSortDescriptor(keyPath: \Study.title, ascending: true)])

--- a/Industrious/Modules/Studies/StudyDetailView.swift
+++ b/Industrious/Modules/Studies/StudyDetailView.swift
@@ -1,5 +1,5 @@
 import SwiftUI
-import CoreData
+@_implementationOnly import CoreData
 import UserNotifications
 
 struct StudyDetailView: View {

--- a/Industrious/Modules/Studies/StudyPicker.swift
+++ b/Industrious/Modules/Studies/StudyPicker.swift
@@ -1,6 +1,5 @@
 import SwiftUI
-import CoreData
-
+@_implementationOnly import CoreData
 struct StudyPicker: View {
     @FetchRequest(sortDescriptors: [NSSortDescriptor(keyPath: \Study.title, ascending: true)])
     private var studies: FetchedResults<Study>

--- a/Industrious/Persistence.swift
+++ b/Industrious/Persistence.swift
@@ -4,9 +4,7 @@
 //
 //  Created by Johnny Villegas on 9/3/25.
 //
-
-import CoreData
-
+@_implementationOnly import CoreData
 struct PersistenceController {
     static let shared = PersistenceController()
 

--- a/IndustriousTests/AggregationTests.swift
+++ b/IndustriousTests/AggregationTests.swift
@@ -1,7 +1,6 @@
 import Testing
 @testable import Industrious
-import CoreData
-
+@_implementationOnly import CoreData
 struct AggregationTests {
     @MainActor
     @Test func sessionDurationsByMonth() async throws {

--- a/IndustriousTests/SessionViewModelTests.swift
+++ b/IndustriousTests/SessionViewModelTests.swift
@@ -1,7 +1,6 @@
 import Testing
 @testable import Industrious
-import CoreData
-
+@_implementationOnly import CoreData
 struct SessionViewModelTests {
     @MainActor
     @Test func timerIncrements() async throws {


### PR DESCRIPTION
## Summary
- make CoreData an implementation-only dependency throughout the app and tests to silence duplicate class warnings

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68bc38404b24832e90696b70b75f52eb