### PR TITLE
Add migration options and safe Core Data fallback

### DIFF
--- a/Industrious/Persistence.swift
+++ b/Industrious/Persistence.swift
@@ -23,21 +23,20 @@ struct PersistenceController {
         if inMemory {
             container.persistentStoreDescriptions.first?.url = URL(fileURLWithPath: "/dev/null")
         }
-        container.loadPersistentStores(completionHandler: { (_, error) in
+        let desc = container.persistentStoreDescriptions.first
+        desc?.setOption(true as NSNumber, forKey: NSMigratePersistentStoresAutomaticallyOption)
+        desc?.setOption(true as NSNumber, forKey: NSInferMappingModelAutomaticallyOption)
+        container.loadPersistentStores { [self] (_, error) in
             if let error = error as NSError? {
-                // Replace this implementation with code to handle the error appropriately.
-                // fatalError() causes the application to generate a crash log and terminate. You should not use this function in a shipping application, although it may be useful during development.
-                /*
-                 Typical reasons for an error here include:
-                 * The parent directory does not exist, cannot be created, or disallows writing.
-                 * The persistent store is not accessible, due to permissions or data protection when the device is locked.
-                 * The device is out of space.
-                 * The store could not be migrated to the current model version.
-                 Check the error message to determine what the actual problem was.
-                 */
-                fatalError("Unresolved error \(error), \(error.userInfo)")
+                print("Unresolved error \(error), \(error.userInfo). Falling back to in-memory store.")
+                container.persistentStoreDescriptions.first?.url = URL(fileURLWithPath: "/dev/null")
+                container.loadPersistentStores { (_, error) in
+                    if let error = error as NSError? {
+                        print("Failed to load in-memory store: \(error), \(error.userInfo)")
+                    }
+                }
             }
-        })
+        }
         container.viewContext.automaticallyMergesChangesFromParent = true
         try? MigrationHelper.migrateLegacyItems(context: container.viewContext)
     }


### PR DESCRIPTION
## Summary
- Enable automatic Core Data migrations
- Replace fatalError with logging and in-memory fallback on store load failure

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `xcodebuild -list` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bc3c7bd174832e9dd11f2eb10cf064