### PR TITLE
Restore automatic source inclusion in Xcode project

### DIFF
--- a/Industrious.xcodeproj/project.pbxproj
+++ b/Industrious.xcodeproj/project.pbxproj
@@ -30,11 +30,11 @@
 /* End PBXFileReference section */
 
 /* Begin PBXGroup section */
-		EA0A548E2E69304500583DB9 /* Industrious */ = {
-			isa = PBXGroup;
-			path = Industrious;
-			sourceTree = "<group>";
-		};
+               EA0A548E2E69304500583DB9 /* Industrious */ = {
+                       isa = PBXFileSystemSynchronizedRootGroup;
+                       path = Industrious;
+                       sourceTree = "<group>";
+               };
 		EA0A54A12E69304700583DB9 /* IndustriousTests */ = {
 			isa = PBXGroup;
 			path = IndustriousTests;


### PR DESCRIPTION
## Summary
- Revert `Industrious` group to `PBXFileSystemSynchronizedRootGroup` so Xcode auto-syncs source files.

## Testing
- `xcodebuild -project Industrious.xcodeproj -scheme Industrious -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 14' build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c04aae2290832e9535d414ce9522ee