### PR TITLE
Define explicit Xcode project file references

### DIFF
--- a/Industrious.xcodeproj/project.pbxproj
+++ b/Industrious.xcodeproj/project.pbxproj
@@ -23,28 +23,154 @@
 		};
 /* End PBXContainerItemProxy section */
 
+/* Begin PBXBuildFile section */
+				C27BA6D280614FA8BA6BF04F /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3C4BE3BAA6A458DB7123C9E /* ContentView.swift */; };
+				94B890EEAC6E4C8AB9C6D471 /* IndustriousApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9E86A3290D74186BA85DEE4 /* IndustriousApp.swift */; };
+				B9A6A146CE0A4C24BCA2770E /* Aggregation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C7A143DBC634C23BE5EDAA5 /* Aggregation.swift */; };
+				CF4025D3AC55431CB30470A0 /* CountersAggregator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 587FC97046CC464591C64417 /* CountersAggregator.swift */; };
+				DC67CCC4F5E24D27AE0A382A /* Entities.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F902520FB14469488C57BD9 /* Entities.swift */; };
+				14146DB3BC714BC0919B99FA /* Enums.swift in Sources */ = {isa = PBXBuildFile; fileRef = 643301D002F0457A803D6F90 /* Enums.swift */; };
+				13BC63202EC2478B8180C369 /* MigrationHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE5835862D7948D4BA9F545F /* MigrationHelpers.swift */; };
+				7ECA80184AFE4AB88966C75D /* PlannedSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = C63C5807A1C14AFCA27B0FFB /* PlannedSession.swift */; };
+				166302D2443A42D08AB2B0BA /* SampleData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B211D7884F840B2B0FE24AC /* SampleData.swift */; };
+				28FE7B6B3F6841B2BF3FC7E7 /* DashboardComponents.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C73CDF0C0004DE3A04B68C8 /* DashboardComponents.swift */; };
+				6C5347827BBF471FB512820D /* DashboardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49B2DBB6FBC84EEF92EAD47F /* DashboardView.swift */; };
+				8DDBE6D065954BD493033511 /* HistoryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 557ECC9976484AA7B2514C90 /* HistoryView.swift */; };
+				BFBC9600629A4013BC09C64C /* MonthDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15017E398B0240D9B36A6625 /* MonthDetailView.swift */; };
+				A9EBD1E35D274E70AC249AB6 /* CounterControlsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01576207D7914AB4A21217FD /* CounterControlsView.swift */; };
+				F4AE267CCE154CB29E123E21 /* DayOffLoggingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74C16644BBC242619B37CF62 /* DayOffLoggingView.swift */; };
+				0FFBA49049F5499199BB4C92 /* PlannerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F07A5FEBB83F40E7AC7B7BE6 /* PlannerView.swift */; };
+				8648A2BE1EA64F3C924438F5 /* WeekPlannerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D7724599DDE42919A9852D2 /* WeekPlannerView.swift */; };
+				0C41002E31E744A984B6FCDB /* SessionViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30E769C0DEC34004A8B8F45A /* SessionViewModel.swift */; };
+				41E6A8EAB4AD4BF6A9DB5799 /* SessionsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E2E665FC5BA478D92B2BCE1 /* SessionsView.swift */; };
+				7C7855F54C0A42348F62F9D4 /* StartSessionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7BBF4E4C18340B3A658D011 /* StartSessionView.swift */; };
+				62750AEA613A4376932DB367 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B23746B12CB04A3C99D36D3F /* SettingsView.swift */; };
+				8E6627FF6C4B46859EC6E7D3 /* StudiesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E11E8323DB346B3819EBF2F /* StudiesView.swift */; };
+				EC4B4EA1BF7F48D3B476BC12 /* StudyDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1DB470C43F44E069564F52C /* StudyDetailView.swift */; };
+				9D3D1A071E6E431289BD8FCF /* StudyPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD309B515A95407BA9CFE027 /* StudyPicker.swift */; };
+				AD9EEB53CEE2406B9871D94A /* NotificationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84532B7560CD4F4386D384DF /* NotificationManager.swift */; };
+				4B89265D7C834B16B4EC4171 /* Persistence.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06F6D81D9134402D9EC09668 /* Persistence.swift */; };
+				58D4A8A61CC841DCA47256D6 /* ActivityType+Color.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0D6CBAD28614D91ABFE10A3 /* ActivityType+Color.swift */; };
+				08B8B92F653D46B0B6DD5225 /* AppColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 990D76749E764A8CB0CD7A10 /* AppColor.swift */; };
+				2968E29949B1475F8DA21CC6 /* Spacing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7118730417AF499E89BB3AC0 /* Spacing.swift */; };
+				14EA44C621F5402C8D756D25 /* Symbols.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA15B14C58FC493692B0DA67 /* Symbols.swift */; };
+				EF99514B87AD4FDC9D3AAF78 /* Typography.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B93AD2521294086BD2F8F6F /* Typography.swift */; };
+				819A402CD4DE4CB7B3C8790E /* ShareSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93A59F209AB74E09A26D1D19 /* ShareSheet.swift */; };
+				59D1B0B4A97B4C59B6705DEE /* AggregationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB8E9CD20FAC49A0962345D3 /* AggregationTests.swift */; };
+				E6FC96736A04401FB8804A8C /* IndustriousTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 296DAB4BE23042B5B50F3331 /* IndustriousTests.swift */; };
+				A4C5E2313FA3456FA1A6FC7A /* SessionViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5472D78E8F754EC49B88145A /* SessionViewModelTests.swift */; };
+				E77FA30201C44C38BA596E77 /* IndustriousUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF9EB3E8BDC94A10A0436178 /* IndustriousUITests.swift */; };
+				3A58DC4C6FAA452885BB8E54 /* IndustriousUITestsLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3EFE1D3FDE0428BA7D27F8E /* IndustriousUITestsLaunchTests.swift */; };
+				6D5DC50B11B14BB9B1754D19 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = F34FBBABD04E4DC8A7591C30 /* Assets.xcassets */; };
+				98E3E1E4C0DC4412B6599967 /* Industrious.xcdatamodeld in Resources */ = {isa = PBXBuildFile; fileRef = 722BEDDAA16E43DFBF7D2642 /* Industrious.xcdatamodeld */; };
+/* End PBXBuildFile section */
+
 /* Begin PBXFileReference section */
 		EA0A548C2E69304500583DB9 /* Industrious.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Industrious.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		EA0A549E2E69304700583DB9 /* IndustriousTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = IndustriousTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		EA0A54A82E69304700583DB9 /* IndustriousUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = IndustriousUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+				F34FBBABD04E4DC8A7591C30 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+				C3C4BE3BAA6A458DB7123C9E /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
+				722BEDDAA16E43DFBF7D2642 /* Industrious.xcdatamodeld */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = Industrious.xcdatamodeld; sourceTree = "<group>"; };
+				D9E86A3290D74186BA85DEE4 /* IndustriousApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IndustriousApp.swift; sourceTree = "<group>"; };
+				6C7A143DBC634C23BE5EDAA5 /* Aggregation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Models/Aggregation.swift; sourceTree = "<group>"; };
+				587FC97046CC464591C64417 /* CountersAggregator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Models/CountersAggregator.swift; sourceTree = "<group>"; };
+				9F902520FB14469488C57BD9 /* Entities.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Models/Entities.swift; sourceTree = "<group>"; };
+				643301D002F0457A803D6F90 /* Enums.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Models/Enums.swift; sourceTree = "<group>"; };
+				FE5835862D7948D4BA9F545F /* MigrationHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Models/MigrationHelpers.swift; sourceTree = "<group>"; };
+				C63C5807A1C14AFCA27B0FFB /* PlannedSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Models/PlannedSession.swift; sourceTree = "<group>"; };
+				0B211D7884F840B2B0FE24AC /* SampleData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Models/SampleData.swift; sourceTree = "<group>"; };
+				7C73CDF0C0004DE3A04B68C8 /* DashboardComponents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Modules/Dashboard/DashboardComponents.swift; sourceTree = "<group>"; };
+				49B2DBB6FBC84EEF92EAD47F /* DashboardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Modules/Dashboard/DashboardView.swift; sourceTree = "<group>"; };
+				557ECC9976484AA7B2514C90 /* HistoryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Modules/History/HistoryView.swift; sourceTree = "<group>"; };
+				15017E398B0240D9B36A6625 /* MonthDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Modules/History/MonthDetailView.swift; sourceTree = "<group>"; };
+				01576207D7914AB4A21217FD /* CounterControlsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Modules/Planner/CounterControlsView.swift; sourceTree = "<group>"; };
+				74C16644BBC242619B37CF62 /* DayOffLoggingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Modules/Planner/DayOffLoggingView.swift; sourceTree = "<group>"; };
+				F07A5FEBB83F40E7AC7B7BE6 /* PlannerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Modules/Planner/PlannerView.swift; sourceTree = "<group>"; };
+				1D7724599DDE42919A9852D2 /* WeekPlannerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Modules/Planner/WeekPlannerView.swift; sourceTree = "<group>"; };
+				30E769C0DEC34004A8B8F45A /* SessionViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Modules/Sessions/SessionViewModel.swift; sourceTree = "<group>"; };
+				5E2E665FC5BA478D92B2BCE1 /* SessionsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Modules/Sessions/SessionsView.swift; sourceTree = "<group>"; };
+				A7BBF4E4C18340B3A658D011 /* StartSessionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Modules/Sessions/StartSessionView.swift; sourceTree = "<group>"; };
+				B23746B12CB04A3C99D36D3F /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Modules/Settings/SettingsView.swift; sourceTree = "<group>"; };
+				0E11E8323DB346B3819EBF2F /* StudiesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Modules/Studies/StudiesView.swift; sourceTree = "<group>"; };
+				D1DB470C43F44E069564F52C /* StudyDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Modules/Studies/StudyDetailView.swift; sourceTree = "<group>"; };
+				BD309B515A95407BA9CFE027 /* StudyPicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Modules/Studies/StudyPicker.swift; sourceTree = "<group>"; };
+				84532B7560CD4F4386D384DF /* NotificationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationManager.swift; sourceTree = "<group>"; };
+				06F6D81D9134402D9EC09668 /* Persistence.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Persistence.swift; sourceTree = "<group>"; };
+				A0D6CBAD28614D91ABFE10A3 /* ActivityType+Color.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Shared/DesignSystem/ActivityType+Color.swift; sourceTree = "<group>"; };
+				990D76749E764A8CB0CD7A10 /* AppColor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Shared/DesignSystem/AppColor.swift; sourceTree = "<group>"; };
+				7118730417AF499E89BB3AC0 /* Spacing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Shared/DesignSystem/Spacing.swift; sourceTree = "<group>"; };
+				FA15B14C58FC493692B0DA67 /* Symbols.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Shared/DesignSystem/Symbols.swift; sourceTree = "<group>"; };
+				9B93AD2521294086BD2F8F6F /* Typography.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Shared/DesignSystem/Typography.swift; sourceTree = "<group>"; };
+				93A59F209AB74E09A26D1D19 /* ShareSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Shared/ShareSheet.swift; sourceTree = "<group>"; };
+				AB8E9CD20FAC49A0962345D3 /* AggregationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AggregationTests.swift; sourceTree = "<group>"; };
+				296DAB4BE23042B5B50F3331 /* IndustriousTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IndustriousTests.swift; sourceTree = "<group>"; };
+				5472D78E8F754EC49B88145A /* SessionViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionViewModelTests.swift; sourceTree = "<group>"; };
+				DF9EB3E8BDC94A10A0436178 /* IndustriousUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IndustriousUITests.swift; sourceTree = "<group>"; };
+				A3EFE1D3FDE0428BA7D27F8E /* IndustriousUITestsLaunchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IndustriousUITestsLaunchTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXGroup section */
                EA0A548E2E69304500583DB9 /* Industrious */ = {
-                       isa = PBXFileSystemSynchronizedRootGroup;
+                       isa = PBXGroup;
+                       children = (
+                                F34FBBABD04E4DC8A7591C30 /* Assets.xcassets */,
+                                C3C4BE3BAA6A458DB7123C9E /* ContentView.swift */,
+                                722BEDDAA16E43DFBF7D2642 /* Industrious.xcdatamodeld */,
+                                D9E86A3290D74186BA85DEE4 /* IndustriousApp.swift */,
+                                6C7A143DBC634C23BE5EDAA5 /* Aggregation.swift */,
+                                587FC97046CC464591C64417 /* CountersAggregator.swift */,
+                                9F902520FB14469488C57BD9 /* Entities.swift */,
+                                643301D002F0457A803D6F90 /* Enums.swift */,
+                                FE5835862D7948D4BA9F545F /* MigrationHelpers.swift */,
+                                C63C5807A1C14AFCA27B0FFB /* PlannedSession.swift */,
+                                0B211D7884F840B2B0FE24AC /* SampleData.swift */,
+                                7C73CDF0C0004DE3A04B68C8 /* DashboardComponents.swift */,
+                                49B2DBB6FBC84EEF92EAD47F /* DashboardView.swift */,
+                                557ECC9976484AA7B2514C90 /* HistoryView.swift */,
+                                15017E398B0240D9B36A6625 /* MonthDetailView.swift */,
+                                01576207D7914AB4A21217FD /* CounterControlsView.swift */,
+                                74C16644BBC242619B37CF62 /* DayOffLoggingView.swift */,
+                                F07A5FEBB83F40E7AC7B7BE6 /* PlannerView.swift */,
+                                1D7724599DDE42919A9852D2 /* WeekPlannerView.swift */,
+                                30E769C0DEC34004A8B8F45A /* SessionViewModel.swift */,
+                                5E2E665FC5BA478D92B2BCE1 /* SessionsView.swift */,
+                                A7BBF4E4C18340B3A658D011 /* StartSessionView.swift */,
+                                B23746B12CB04A3C99D36D3F /* SettingsView.swift */,
+                                0E11E8323DB346B3819EBF2F /* StudiesView.swift */,
+                                D1DB470C43F44E069564F52C /* StudyDetailView.swift */,
+                                BD309B515A95407BA9CFE027 /* StudyPicker.swift */,
+                                84532B7560CD4F4386D384DF /* NotificationManager.swift */,
+                                06F6D81D9134402D9EC09668 /* Persistence.swift */,
+                                A0D6CBAD28614D91ABFE10A3 /* ActivityType+Color.swift */,
+                                990D76749E764A8CB0CD7A10 /* AppColor.swift */,
+                                7118730417AF499E89BB3AC0 /* Spacing.swift */,
+                                FA15B14C58FC493692B0DA67 /* Symbols.swift */,
+                                9B93AD2521294086BD2F8F6F /* Typography.swift */,
+                                93A59F209AB74E09A26D1D19 /* ShareSheet.swift */,
+                       );
                        path = Industrious;
                        sourceTree = "<group>";
                };
-		EA0A54A12E69304700583DB9 /* IndustriousTests */ = {
-			isa = PBXGroup;
-			path = IndustriousTests;
-			sourceTree = "<group>";
-		};
-		EA0A54AB2E69304700583DB9 /* IndustriousUITests */ = {
-			isa = PBXGroup;
-			path = IndustriousUITests;
-			sourceTree = "<group>";
-		};
+                EA0A54A12E69304700583DB9 /* IndustriousTests */ = {
+                        isa = PBXGroup;
+                        children = (
+                                AB8E9CD20FAC49A0962345D3 /* AggregationTests.swift */,
+                                296DAB4BE23042B5B50F3331 /* IndustriousTests.swift */,
+                                5472D78E8F754EC49B88145A /* SessionViewModelTests.swift */,
+                        );
+                        path = IndustriousTests;
+                        sourceTree = "<group>";
+                };
+                EA0A54AB2E69304700583DB9 /* IndustriousUITests */ = {
+                        isa = PBXGroup;
+                        children = (
+                                DF9EB3E8BDC94A10A0436178 /* IndustriousUITests.swift */,
+                                A3EFE1D3FDE0428BA7D27F8E /* IndustriousUITestsLaunchTests.swift */,
+                        );
+                        path = IndustriousUITests;
+                        sourceTree = "<group>";
+                };
 /* End PBXGroup section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -107,9 +233,6 @@
 			);
 			dependencies = (
 			);
-			fileSystemSynchronizedGroups = (
-				EA0A548E2E69304500583DB9 /* Industrious */,
-			);
 			name = Industrious;
 			packageProductDependencies = (
 			);
@@ -130,9 +253,6 @@
 			dependencies = (
 				EA0A54A02E69304700583DB9 /* PBXTargetDependency */,
 			);
-			fileSystemSynchronizedGroups = (
-				EA0A54A12E69304700583DB9 /* IndustriousTests */,
-			);
 			name = IndustriousTests;
 			packageProductDependencies = (
 			);
@@ -152,9 +272,6 @@
 			);
 			dependencies = (
 				EA0A54AA2E69304700583DB9 /* PBXTargetDependency */,
-			);
-			fileSystemSynchronizedGroups = (
-				EA0A54AB2E69304700583DB9 /* IndustriousUITests */,
 			);
 			name = IndustriousUITests;
 			packageProductDependencies = (
@@ -208,13 +325,15 @@
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
-		EA0A548A2E69304500583DB9 /* Resources */ = {
-			isa = PBXResourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
+                EA0A548A2E69304500583DB9 /* Resources */ = {
+                        isa = PBXResourcesBuildPhase;
+                        buildActionMask = 2147483647;
+                        files = (
+                                6D5DC50B11B14BB9B1754D19 /* Assets.xcassets in Resources */,
+                                98E3E1E4C0DC4412B6599967 /* Industrious.xcdatamodeld in Resources */,
+                        );
+                        runOnlyForDeploymentPostprocessing = 0;
+                };
 		EA0A549C2E69304700583DB9 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -232,27 +351,64 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
-		EA0A54882E69304500583DB9 /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		EA0A549A2E69304700583DB9 /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		EA0A54A42E69304700583DB9 /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
+                EA0A54882E69304500583DB9 /* Sources */ = {
+                        isa = PBXSourcesBuildPhase;
+                        buildActionMask = 2147483647;
+                        files = (
+                                C27BA6D280614FA8BA6BF04F /* ContentView.swift in Sources */,
+                                94B890EEAC6E4C8AB9C6D471 /* IndustriousApp.swift in Sources */,
+                                B9A6A146CE0A4C24BCA2770E /* Aggregation.swift in Sources */,
+                                CF4025D3AC55431CB30470A0 /* CountersAggregator.swift in Sources */,
+                                DC67CCC4F5E24D27AE0A382A /* Entities.swift in Sources */,
+                                14146DB3BC714BC0919B99FA /* Enums.swift in Sources */,
+                                13BC63202EC2478B8180C369 /* MigrationHelpers.swift in Sources */,
+                                7ECA80184AFE4AB88966C75D /* PlannedSession.swift in Sources */,
+                                166302D2443A42D08AB2B0BA /* SampleData.swift in Sources */,
+                                28FE7B6B3F6841B2BF3FC7E7 /* DashboardComponents.swift in Sources */,
+                                6C5347827BBF471FB512820D /* DashboardView.swift in Sources */,
+                                8DDBE6D065954BD493033511 /* HistoryView.swift in Sources */,
+                                BFBC9600629A4013BC09C64C /* MonthDetailView.swift in Sources */,
+                                A9EBD1E35D274E70AC249AB6 /* CounterControlsView.swift in Sources */,
+                                F4AE267CCE154CB29E123E21 /* DayOffLoggingView.swift in Sources */,
+                                0FFBA49049F5499199BB4C92 /* PlannerView.swift in Sources */,
+                                8648A2BE1EA64F3C924438F5 /* WeekPlannerView.swift in Sources */,
+                                0C41002E31E744A984B6FCDB /* SessionViewModel.swift in Sources */,
+                                41E6A8EAB4AD4BF6A9DB5799 /* SessionsView.swift in Sources */,
+                                7C7855F54C0A42348F62F9D4 /* StartSessionView.swift in Sources */,
+                                62750AEA613A4376932DB367 /* SettingsView.swift in Sources */,
+                                8E6627FF6C4B46859EC6E7D3 /* StudiesView.swift in Sources */,
+                                EC4B4EA1BF7F48D3B476BC12 /* StudyDetailView.swift in Sources */,
+                                9D3D1A071E6E431289BD8FCF /* StudyPicker.swift in Sources */,
+                                AD9EEB53CEE2406B9871D94A /* NotificationManager.swift in Sources */,
+                                4B89265D7C834B16B4EC4171 /* Persistence.swift in Sources */,
+                                58D4A8A61CC841DCA47256D6 /* ActivityType+Color.swift in Sources */,
+                                08B8B92F653D46B0B6DD5225 /* AppColor.swift in Sources */,
+                                2968E29949B1475F8DA21CC6 /* Spacing.swift in Sources */,
+                                14EA44C621F5402C8D756D25 /* Symbols.swift in Sources */,
+                                EF99514B87AD4FDC9D3AAF78 /* Typography.swift in Sources */,
+                                819A402CD4DE4CB7B3C8790E /* ShareSheet.swift in Sources */,
+                        );
+                        runOnlyForDeploymentPostprocessing = 0;
+                };
+                EA0A549A2E69304700583DB9 /* Sources */ = {
+                        isa = PBXSourcesBuildPhase;
+                        buildActionMask = 2147483647;
+                        files = (
+                                59D1B0B4A97B4C59B6705DEE /* AggregationTests.swift in Sources */,
+                                E6FC96736A04401FB8804A8C /* IndustriousTests.swift in Sources */,
+                                A4C5E2313FA3456FA1A6FC7A /* SessionViewModelTests.swift in Sources */,
+                        );
+                        runOnlyForDeploymentPostprocessing = 0;
+                };
+                EA0A54A42E69304700583DB9 /* Sources */ = {
+                        isa = PBXSourcesBuildPhase;
+                        buildActionMask = 2147483647;
+                        files = (
+                                E77FA30201C44C38BA596E77 /* IndustriousUITests.swift in Sources */,
+                                3A58DC4C6FAA452885BB8E54 /* IndustriousUITestsLaunchTests.swift in Sources */,
+                        );
+                        runOnlyForDeploymentPostprocessing = 0;
+                };
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */


### PR DESCRIPTION
## Summary
- Replace `PBXFileSystemSynchronizedRootGroup` with explicit `PBXGroup` children and file references for all app, test, and resource files
- Link every Swift source into its target's Sources build phase and include the asset catalog and Core Data model in Resources

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68c04cce1e0c832e90a83e8036590c63